### PR TITLE
Fetch: Test to tell EXISTS count earlier.

### DIFF
--- a/Cassandane/Cyrus/Fetch.pm
+++ b/Cassandane/Cyrus/Fetch.pm
@@ -752,5 +752,57 @@ sub test_fetch_flags_before_exists
     $admintalk->_imap_cmd("fetch", 1, \%handlers, \'1:*', '(flags)');
 }
 
+sub test_tell_exists_count_earlier
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->select('user.cassandane');
+
+    $self->make_message("Test Message 1");
+    $admintalk->fetch('1:*', '(flags)');
+
+    $self->make_message("Test Message 2");
+    $admintalk->fetch('2:*', '(flags)');
+
+    $self->make_message("Test Message 3");
+    $admintalk->fetch('3:*', '(uid flags)');
+
+    $admintalk->unselect();
+    $admintalk->select('user.cassandane');
+
+    $imaptalk->store('2', '+flags', '(\\Flagged)');
+    $self->make_message("Test Message 4");
+
+    my %handlers;
+    {
+        my $sawfetch = -1;
+        my $sawmsg2fetch = -1;
+        my $sawmsg3fetch = -1;
+        my $sawmsg4fetch = -1;
+        use Data::Dumper;
+        $handlers{fetch} = sub {
+            $sawfetch = 1 if $sawfetch < 0;
+
+            if ($_[2] == 2) { $sawmsg2fetch = $_[2] }
+            elsif ($_[2] == 3) {
+                $sawmsg3fetch = $_[2];
+                die "Got FETCH for 3 before 2" if $sawmsg2fetch < 0;
+            }
+            elsif ($_[2] == 3) {
+                $sawmsg4fetch = $_[2];
+                die "Got FETCH for 4 before 2" if $sawmsg2fetch < 0;
+                die "Got FETCH for 4 before 3" if $sawmsg3fetch < 0;
+            }
+            else { }
+        };
+        $handlers{exists} = sub { die "Got EXISTS after FETCH for $_[2]" if $sawfetch > 0; };
+    }
+
+    $admintalk->_imap_cmd("fetch", 1, \%handlers, \'3:*', '(uid flags)');
+}
+
 
 1;


### PR DESCRIPTION
This patch adds support to test the `FETCH` changes made to
`index_fetch` to single-pass inline unsolicited FETCHes.

This is a test to fix https://github.com/cyrusimap/cyrus-imapd/issues/1971.