### PR TITLE
[Idle] Increase time tolerance for timeout test.

### DIFF
--- a/Cassandane/Cyrus/Idle.pm
+++ b/Cassandane/Cyrus/Idle.pm
@@ -589,7 +589,7 @@ sub test_idled_default_timeout
     my $date2 = DateTime->from_epoch(epoch => time());
 
     my $dur = $date2->epoch - $date1->epoch;
-    $self->asser($dur < 5, "IDLE took longer than expected");
+    $self->asser($dur < 15, "IDLE took longer than expected");
 }
 
 


### PR DESCRIPTION
Running the detault timeout test in a docker container fails because the
test takes longer to run. Bumping the timeout for the test
`idled_default_timeout` to `15 seconds` from the current `5 seconds`.