### PR TITLE
TesterJMAP: Recurse to find tests in t/ of JMAP::TestSuite

### DIFF
--- a/Cassandane/Cyrus/TesterJMAP.pm
+++ b/Cassandane/Cyrus/TesterJMAP.pm
@@ -191,20 +191,27 @@ sub run_test
     my $logdir = $self->{instance}->{basedir} .  "/logdir";
 
     my $service = $self->{instance}->get_service("http");
+    my $imap = $self->{instance}->get_service("imap");
 
     local $ENV{JMAP_SERVER_ADAPTER_FILE} = $configfile;
 
     open(FH, ">$configfile");
 
     print FH encode_json({
-        adapter => 'Cyrus',
-        base_uri => 'http://' . $service->host() . ':' . $service->port() . '/',
-        credentials => [
+        adapter          => 'Cyrus',
+        base_uri         => 'http://' . $service->host() . ':' . $service->port() . '/',
+        cyrus_host       => $imap->host(),
+        cyrus_port       => $imap->port(),
+        cyrus_admin_user => 'admin',
+        cyrus_admin_pass => 'testpw',
+        no_sasl          => 1,
+        credentials      => [
             {
                 username => 'cassandane',
                 password => 'pass',
             },
         ],
+        cyrus_hierarchy_separator => '.',
     });
     close(FH);
 

--- a/Cassandane/Cyrus/TesterJMAP.pm
+++ b/Cassandane/Cyrus/TesterJMAP.pm
@@ -212,6 +212,7 @@ sub run_test
             },
         ],
         cyrus_hierarchy_separator => '.',
+        cyrus_prefix => $self->{instance}->{cyrus_prefix}
     });
     close(FH);
 


### PR DESCRIPTION
Also, if the AUTHOR_TESTING environment variable is set, look in xt/

With this, test specification changes slightly:

Instead of:

  TesterJMAP.previews

You'd do:

  TesterJMAP.t:previews

(providing paths with / replaced with :)