### PR TITLE
Instruct JMAP::TestSuite to include more info in verbose mode

### DIFF
--- a/Cassandane/Cyrus/TesterJMAP.pm
+++ b/Cassandane/Cyrus/TesterJMAP.pm
@@ -222,6 +222,9 @@ sub run_test
 
     $name =~ s{:}{/}g;
 
+    local $ENV{JMTS_TEST_OUTPUT_TO_STDERR} = 1 if get_verbose;
+    local $ENV{JMTS_TELEMETRY} = 1 if get_verbose;
+
     $self->{instance}->run_command({
             redirects => { stderr => $errfile, stdout => $outfile },
             workingdir => $logdir,


### PR DESCRIPTION
This includes:

 * Test output (from ok(), etc)
 * JMAP::Tester::Logger output about requests/responses to cyrus