### PR TITLE
Add :needs_foo_bar attribute for marking tests as dependent on optional features

### DIFF
--- a/Cassandane/BuildInfo.pm
+++ b/Cassandane/BuildInfo.pm
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2018 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::BuildInfo;
+use JSON;
+
+use lib '.';
+use Cassandane::Cassini;
+use Cassandane::Util::Log;
+
+sub new {
+    my $class = shift;
+    my %params = @_;
+    my $self = {};
+
+    my $cassini = Cassandane::Cassini->instance();
+
+    my $prefix = $cassini->val("cyrus default", 'prefix', '/usr/cyrus');
+    $prefix = $params{cyrus_prefix}
+	if defined $params{cyrus_prefix};
+
+    my $destdir = $cassini->val("cyrus default", 'destdir', '');
+    $destdir = $params{cyrus_destdir}
+	if defined $params{cyrus_destdir};
+
+    $self->{data} = _read_buildinfo($destdir, $prefix);
+
+    return bless $self, $class;
+}
+
+sub _read_buildinfo
+{
+    my ($destdir, $prefix) = @_;
+
+    my $cyr_buildinfo = "$destdir$prefix/sbin/cyr_buildinfo";
+    return if not -x $cyr_buildinfo;
+
+    my $jsondata = qx($cyr_buildinfo);
+    return if not $jsondata;
+
+    return JSON::decode_json($jsondata);
+
+}
+
+sub get
+{
+    my ($self, $category, $key) = @_;
+
+    return if not exists $self->{data}->{$category}->{$key};
+    return $self->{data}->{$category}->{$key};
+}
+
+1;

--- a/Cassandane/Cyrus/Autocreate.pm
+++ b/Cassandane/Cyrus/Autocreate.pm
@@ -117,7 +117,7 @@ sub test_autocreate_specialuse
 }
 
 sub test_autocreate_sieve_script_generation
-    :min_version_3_0
+    :min_version_3_0 :needs_component_sieve
 {
     my ($self) = @_;
     return unless $self->{test_autocreate};

--- a/Cassandane/Cyrus/Autocreate.pm
+++ b/Cassandane/Cyrus/Autocreate.pm
@@ -72,11 +72,6 @@ sub set_up
 {
     my ($self) = @_;
     $self->SUPER::set_up();
-    if (not $self->{instance}->{buildinfo}->get('component', 'autocreate')) {
-        xlog "autocreate not enabled. Skipping tests.";
-        return;
-    }
-    $self->{test_autocreate} = 1;
 }
 
 sub tear_down
@@ -86,10 +81,9 @@ sub tear_down
 }
 
 sub test_autocreate_specialuse
-     :min_version_3_0
+     :min_version_3_0 :needs_component_autocreate
 {
     my ($self) = @_;
-    return unless $self->{test_autocreate};
 
     my $svc = $self->{instance}->get_service('imap');
     my $store = $svc->create_store(username => 'foo');
@@ -117,10 +111,9 @@ sub test_autocreate_specialuse
 }
 
 sub test_autocreate_sieve_script_generation
-    :min_version_3_0 :needs_component_sieve
+    :min_version_3_0 :needs_component_autocreate :needs_component_sieve
 {
     my ($self) = @_;
-    return unless $self->{test_autocreate};
 
     my $basedir = $self->{instance}->get_basedir();
     my $sieve_script_path = $basedir . "/conf/foo_sieve.script";

--- a/Cassandane/Cyrus/Autocreate.pm
+++ b/Cassandane/Cyrus/Autocreate.pm
@@ -72,7 +72,7 @@ sub set_up
 {
     my ($self) = @_;
     $self->SUPER::set_up();
-    if (not $self->{instance}->{buildinfo}->{component}->{autocreate}) {
+    if (not $self->{instance}->{buildinfo}->get('component', 'autocreate')) {
         xlog "autocreate not enabled. Skipping tests.";
         return;
     }

--- a/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/Cassandane/Cyrus/CaldavAlarm.pm
@@ -84,7 +84,7 @@ sub set_up
 	expandurl => 1,
     );
 
-    if (not $self->{instance}->{buildinfo}->{component}->{calalarmd}) {
+    if (not $self->{instance}->{buildinfo}->get('component', 'calalarmd')) {
         xlog "calalarmd not enabled. Skipping tests.";
         return;
     }

--- a/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/Cassandane/Cyrus/CaldavAlarm.pm
@@ -83,13 +83,6 @@ sub set_up
 	url => '/',
 	expandurl => 1,
     );
-
-    if (not $self->{instance}->{buildinfo}->get('component', 'calalarmd')) {
-        xlog "calalarmd not enabled. Skipping tests.";
-        return;
-    }
-    $self->{test_calalarmd} = 1;
-
 }
 
 sub _can_match {
@@ -159,10 +152,9 @@ sub tear_down
 }
 
 sub test_simple
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -241,10 +233,9 @@ EOF
 }
 
 sub test_simple_reconstruct
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -329,10 +320,9 @@ EOF
 }
 
 sub test_reschedule_later
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -431,10 +421,9 @@ EOF
 }
 
 sub test_override
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -539,10 +528,9 @@ EOF
 }
 
 sub test_override_exception
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -649,10 +637,9 @@ EOF
 }
 
 sub test_floating_notz
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -721,10 +708,9 @@ EOF
 }
 
 sub test_floating_sametz
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -806,7 +792,7 @@ EOF
 }
 
 sub test_floating_differenttz
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
     return if not $self->{test_calalarmd};
@@ -902,10 +888,9 @@ EOF
 }
 
 sub test_replication_at1
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     $self->assert_not_null($self->{replica});
 
@@ -1035,10 +1020,9 @@ EOF
 }
 
 sub test_override_double
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -1147,10 +1131,9 @@ EOF
 }
 
 sub test_allday_notz
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -1220,10 +1203,9 @@ EOF
 }
 
 sub test_allday_sametz
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -1306,10 +1288,9 @@ EOF
 }
 
 sub test_replication_withalarms_in_tz_with_dst
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -1413,10 +1394,9 @@ EOF
 }
 
 sub test_replication_withalarms_in_tz_without_dst
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -1512,10 +1492,9 @@ EOF
 }
 
 sub test_reschedule_exception
-    :min_version_3_0
+    :min_version_3_0 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     # FIXME disable this test until calalarmd is fixed
     return;
@@ -1698,10 +1677,9 @@ EOF
 }
 
 sub test_simple_multiuser
-    :min_version_3_1
+    :min_version_3_1 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -1851,10 +1829,9 @@ EOF
 }
 
 sub test_override_multiuser
-    :min_version_3_1
+    :min_version_3_1 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 
@@ -2036,10 +2013,9 @@ EOF
 }
 
 sub test_simple_multiuser_sametime
-    :min_version_3_1
+    :min_version_3_1 :needs_component_calalarmd
 {
     my ($self) = @_;
-    return if not $self->{test_calalarmd};
 
     my $CalDAV = $self->{caldav};
 

--- a/Cassandane/Cyrus/ClamAV.pm
+++ b/Cassandane/Cyrus/ClamAV.pm
@@ -79,7 +79,7 @@ sub set_up
 {
     my ($self) = @_;
     $self->SUPER::set_up();
-    if (not $self->{instance}->{buildinfo}->{dependency}->{clamav}) {
+    if (not $self->{instance}->{buildinfo}->get('dependency', 'clamav')) {
         xlog "clamav not enabled. Skipping tests.";
         return;
     }

--- a/Cassandane/Cyrus/ClamAV.pm
+++ b/Cassandane/Cyrus/ClamAV.pm
@@ -79,17 +79,11 @@ sub set_up
 {
     my ($self) = @_;
     $self->SUPER::set_up();
-    if (not $self->{instance}->{buildinfo}->get('dependency', 'clamav')) {
-        xlog "clamav not enabled. Skipping tests.";
-        return;
-    }
 
     # set up a shared folder that's easy to write to
     my $admintalk = $self->{adminstore}->get_client();
     $admintalk->create('shared.folder');
     $admintalk->setacl('shared.folder', 'cassandane' => 'lrswipkxtecd');
-
-    $self->{test_clamav} = 1;
 }
 
 sub tear_down
@@ -99,18 +93,18 @@ sub tear_down
 }
 
 sub test_aaasetup
+    :needs_dependency_clamav
 {
     my ($self) = @_;
-    return if not $self->{test_clamav};
 
     # does everything set up and tear down cleanly?
     $self->assert(1);
 }
 
 sub test_remove_infected
+    :needs_dependency_clamav
 {
     my ($self) = @_;
-    return if not $self->{test_clamav};
 
     $self->{store}->set_fetch_attributes(qw(uid flags));
 

--- a/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/Cassandane/Cyrus/JMAPCalendars.pm
@@ -81,7 +81,7 @@ sub set_up
 }
 
 sub test_calendar_get
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -125,7 +125,7 @@ sub test_calendar_get
 }
 
 sub test_calendar_get_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -193,7 +193,7 @@ sub test_calendar_get_shared
 
 
 sub test_calendar_get_default
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -208,7 +208,7 @@ sub test_calendar_get_default
 }
 
 sub test_calendar_set
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -269,7 +269,7 @@ sub test_calendar_set
 }
 
 sub test_calendar_set_state
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -370,7 +370,7 @@ sub test_calendar_set_state
 }
 
 sub test_calendar_set_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -479,7 +479,7 @@ sub test_calendar_set_shared
 
 
 sub test_calendar_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -583,7 +583,7 @@ sub test_calendar_changes
 }
 
 sub test_calendar_set_error
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -672,7 +672,7 @@ sub test_calendar_set_error
 }
 
 sub test_calendar_set_badname
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -696,7 +696,7 @@ sub test_calendar_set_badname
 }
 
 sub test_calendar_set_destroydefault
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -919,7 +919,7 @@ sub icalfile
 }
 
 sub test_calendarevent_get_simple
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -948,7 +948,7 @@ sub test_calendarevent_get_simple
 }
 
 sub test_calendarevent_get_privacy
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -960,7 +960,7 @@ sub test_calendarevent_get_privacy
 }
 
 sub test_calendarevent_get_properties
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -976,7 +976,7 @@ sub test_calendarevent_get_properties
 }
 
 sub test_calendarevent_get_relatedto
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -993,7 +993,7 @@ sub test_calendarevent_get_relatedto
 }
 
 sub test_calendarevent_get_links
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1017,7 +1017,7 @@ sub test_calendarevent_get_links
 
 
 sub test_calendarevent_get_rscale
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1034,7 +1034,7 @@ sub test_calendarevent_get_rscale
 }
 
 sub test_calendarevent_get_endtimezone
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1053,7 +1053,7 @@ sub test_calendarevent_get_endtimezone
 }
 
 sub test_calendarevent_get_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1067,7 +1067,7 @@ sub test_calendarevent_get_keywords
 }
 
 sub test_calendarevent_get_description
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1080,7 +1080,7 @@ sub test_calendarevent_get_description
 }
 
 sub test_calendarevent_get_participants
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1121,7 +1121,7 @@ sub test_calendarevent_get_participants
 }
 
 sub test_calendarevent_get_recurrence
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1154,7 +1154,7 @@ sub test_calendarevent_get_recurrence
 }
 
 sub test_calendarevent_get_rdate_period
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1170,7 +1170,7 @@ sub test_calendarevent_get_rdate_period
 
 
 sub test_calendarevent_get_recurrenceoverrides
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1200,7 +1200,7 @@ sub test_calendarevent_get_recurrenceoverrides
 }
 
 sub test_calendarevent_get_alerts
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1261,7 +1261,7 @@ sub test_calendarevent_get_alerts
 }
 
 sub test_calendarevent_get_locations
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1274,7 +1274,7 @@ sub test_calendarevent_get_locations
 }
 
 sub test_calendarevent_get_locations_uri
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1288,7 +1288,7 @@ sub test_calendarevent_get_locations_uri
 }
 
 sub test_calendarevent_get_locations_geo
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1301,7 +1301,7 @@ sub test_calendarevent_get_locations_geo
 }
 
 sub test_calendarevent_get_locations_apple
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1315,7 +1315,7 @@ sub test_calendarevent_get_locations_apple
 }
 
 sub test_calendarevent_get_locations_conference
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1342,7 +1342,7 @@ sub test_calendarevent_get_locations_conference
 }
 
 sub test_calendarevent_get_infinite_delegates
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1435,7 +1435,7 @@ sub createcalendar
 }
 
 sub test_calendarevent_set_type
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1481,7 +1481,7 @@ sub test_calendarevent_set_type
 
 
 sub test_calendarevent_set_simple
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1514,7 +1514,7 @@ sub test_calendarevent_set_simple
 }
 
 sub test_calendarevent_set_bymonth
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
 	my ($self) = @_;
 
@@ -1555,7 +1555,7 @@ sub test_calendarevent_set_bymonth
 }
 
 sub test_calendarevent_set_relatedto
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1590,7 +1590,7 @@ sub test_calendarevent_set_relatedto
 }
 
 sub test_calendarevent_set_prodid
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1621,7 +1621,7 @@ sub test_calendarevent_set_prodid
 }
 
 sub test_calendarevent_set_endtimezone
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1662,7 +1662,7 @@ sub test_calendarevent_set_endtimezone
 }
 
 sub test_calendarevent_set_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1686,7 +1686,7 @@ sub test_calendarevent_set_keywords
 }
 
 sub test_calendarevent_set_endtimezone_recurrence
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1728,7 +1728,7 @@ sub test_calendarevent_set_endtimezone_recurrence
 }
 
 sub test_calendarevent_set_description
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1758,7 +1758,7 @@ sub test_calendarevent_set_description
 }
 
 sub test_calendarevent_set_links
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1806,7 +1806,7 @@ sub test_calendarevent_set_links
 }
 
 sub test_calendarevent_set_locations
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1889,7 +1889,7 @@ sub test_calendarevent_set_locations
 }
 
 sub test_calendarevent_set_locations_single
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1933,7 +1933,7 @@ sub test_calendarevent_set_locations_single
 }
 
 sub test_calendarevent_set_recurrence
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1972,7 +1972,7 @@ sub test_calendarevent_set_recurrence
 }
 
 sub test_calendarevent_set_recurrenceoverrides
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2049,7 +2049,7 @@ sub test_calendarevent_set_recurrenceoverrides
 }
 
 sub test_calendarevent_set_participants
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2153,7 +2153,7 @@ sub test_calendarevent_set_participants
 }
 
 sub test_calendarevent_set_alerts
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2219,7 +2219,7 @@ sub test_calendarevent_set_alerts
 }
 
 sub test_calendarevent_set_participantid
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2264,7 +2264,7 @@ sub test_calendarevent_set_participantid
 
 
 sub test_calendarevent_set_isallday
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2313,7 +2313,7 @@ sub test_calendarevent_set_isallday
 }
 
 sub test_calendarevent_set_move
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2387,7 +2387,7 @@ sub test_calendarevent_set_move
 }
 
 sub test_calendarevent_set_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2548,7 +2548,7 @@ sub test_calendarevent_set_shared
 
 
 sub test_calendarevent_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2719,7 +2719,7 @@ sub test_calendarevent_changes
 }
 
 sub test_calendarevent_query
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2849,7 +2849,7 @@ sub test_calendarevent_query
 }
 
 sub test_calendarevent_query_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3010,7 +3010,7 @@ sub test_calendarevent_query_shared
 }
 
 sub test_calendarevent_query_datetime
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3118,7 +3118,7 @@ sub test_calendarevent_query_datetime
 }
 
 sub test_calendarevent_query_date
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3247,7 +3247,7 @@ sub test_calendarevent_query_date
 }
 
 sub test_calendarevent_query_text
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3358,7 +3358,7 @@ sub test_calendarevent_query_text
 }
 
 sub test_calendarevent_query_unixepoch
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3401,7 +3401,7 @@ sub test_calendarevent_query_unixepoch
 
 
 sub test_calendarevent_set_caldav
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3529,7 +3529,7 @@ EOF
 }
 
 sub test_calendarevent_set_schedule_request
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3581,7 +3581,7 @@ sub test_calendarevent_set_schedule_request
 }
 
 sub test_calendarevent_set_schedule_reply
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3642,7 +3642,7 @@ sub test_calendarevent_set_schedule_reply
 }
 
 sub test_calendarevent_set_schedule_cancel
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3706,7 +3706,7 @@ sub test_calendarevent_set_schedule_cancel
 }
 
 sub test_misc_creationids
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3741,7 +3741,7 @@ sub test_misc_creationids
 }
 
 sub test_misc_timezone_expansion
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -3781,7 +3781,7 @@ sub test_misc_timezone_expansion
 }
 
 sub test_calendarevent_set_uid
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/Cassandane/Cyrus/JMAPCalendars.pm
@@ -60,10 +60,18 @@ sub new
 {
     my ($class, @args) = @_;
     my $config = Cassandane::Config->default()->clone();
-    $config->set(caldav_historical_age => -1);
+    $config->set(caldav_realm => 'Cassandane',
+		 caldav_historical_age => -1,
+		 conversations => 'yes',
+		 httpmodules => 'carddav caldav jmap',
+		 httpallowcompress => 'no');
+
     return $class->SUPER::new({
-        config => $config,
-                              }, @args);
+	config => $config,
+	jmap => 1,
+	adminstore => 1,
+	services => [ 'imap', 'http' ]
+    }, @args);
 }
 
 sub set_up
@@ -73,7 +81,7 @@ sub set_up
 }
 
 sub test_calendar_get
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -117,7 +125,7 @@ sub test_calendar_get
 }
 
 sub test_calendar_get_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -185,7 +193,7 @@ sub test_calendar_get_shared
 
 
 sub test_calendar_get_default
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -200,7 +208,7 @@ sub test_calendar_get_default
 }
 
 sub test_calendar_set
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -261,7 +269,7 @@ sub test_calendar_set
 }
 
 sub test_calendar_set_state
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -362,7 +370,7 @@ sub test_calendar_set_state
 }
 
 sub test_calendar_set_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -471,7 +479,7 @@ sub test_calendar_set_shared
 
 
 sub test_calendar_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -575,7 +583,7 @@ sub test_calendar_changes
 }
 
 sub test_calendar_set_error
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -664,7 +672,7 @@ sub test_calendar_set_error
 }
 
 sub test_calendar_set_badname
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -688,7 +696,7 @@ sub test_calendar_set_badname
 }
 
 sub test_calendar_set_destroydefault
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -911,7 +919,7 @@ sub icalfile
 }
 
 sub test_calendarevent_get_simple
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -940,7 +948,7 @@ sub test_calendarevent_get_simple
 }
 
 sub test_calendarevent_get_privacy
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -952,7 +960,7 @@ sub test_calendarevent_get_privacy
 }
 
 sub test_calendarevent_get_properties
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -968,7 +976,7 @@ sub test_calendarevent_get_properties
 }
 
 sub test_calendarevent_get_relatedto
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -985,7 +993,7 @@ sub test_calendarevent_get_relatedto
 }
 
 sub test_calendarevent_get_links
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1009,7 +1017,7 @@ sub test_calendarevent_get_links
 
 
 sub test_calendarevent_get_rscale
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1026,7 +1034,7 @@ sub test_calendarevent_get_rscale
 }
 
 sub test_calendarevent_get_endtimezone
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1045,7 +1053,7 @@ sub test_calendarevent_get_endtimezone
 }
 
 sub test_calendarevent_get_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1059,7 +1067,7 @@ sub test_calendarevent_get_keywords
 }
 
 sub test_calendarevent_get_description
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1072,7 +1080,7 @@ sub test_calendarevent_get_description
 }
 
 sub test_calendarevent_get_participants
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1113,7 +1121,7 @@ sub test_calendarevent_get_participants
 }
 
 sub test_calendarevent_get_recurrence
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1146,7 +1154,7 @@ sub test_calendarevent_get_recurrence
 }
 
 sub test_calendarevent_get_rdate_period
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1162,7 +1170,7 @@ sub test_calendarevent_get_rdate_period
 
 
 sub test_calendarevent_get_recurrenceoverrides
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1192,7 +1200,7 @@ sub test_calendarevent_get_recurrenceoverrides
 }
 
 sub test_calendarevent_get_alerts
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1253,7 +1261,7 @@ sub test_calendarevent_get_alerts
 }
 
 sub test_calendarevent_get_locations
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1266,7 +1274,7 @@ sub test_calendarevent_get_locations
 }
 
 sub test_calendarevent_get_locations_uri
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1280,7 +1288,7 @@ sub test_calendarevent_get_locations_uri
 }
 
 sub test_calendarevent_get_locations_geo
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1293,7 +1301,7 @@ sub test_calendarevent_get_locations_geo
 }
 
 sub test_calendarevent_get_locations_apple
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1307,7 +1315,7 @@ sub test_calendarevent_get_locations_apple
 }
 
 sub test_calendarevent_get_locations_conference
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1334,7 +1342,7 @@ sub test_calendarevent_get_locations_conference
 }
 
 sub test_calendarevent_get_infinite_delegates
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1427,7 +1435,7 @@ sub createcalendar
 }
 
 sub test_calendarevent_set_type
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1473,7 +1481,7 @@ sub test_calendarevent_set_type
 
 
 sub test_calendarevent_set_simple
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1506,7 +1514,7 @@ sub test_calendarevent_set_simple
 }
 
 sub test_calendarevent_set_bymonth
-:JMAP :min_version_3_1
+    :min_version_3_1
 {
 	my ($self) = @_;
 
@@ -1547,7 +1555,7 @@ sub test_calendarevent_set_bymonth
 }
 
 sub test_calendarevent_set_relatedto
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1582,7 +1590,7 @@ sub test_calendarevent_set_relatedto
 }
 
 sub test_calendarevent_set_prodid
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1613,7 +1621,7 @@ sub test_calendarevent_set_prodid
 }
 
 sub test_calendarevent_set_endtimezone
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1654,7 +1662,7 @@ sub test_calendarevent_set_endtimezone
 }
 
 sub test_calendarevent_set_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1678,7 +1686,7 @@ sub test_calendarevent_set_keywords
 }
 
 sub test_calendarevent_set_endtimezone_recurrence
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1720,7 +1728,7 @@ sub test_calendarevent_set_endtimezone_recurrence
 }
 
 sub test_calendarevent_set_description
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1750,7 +1758,7 @@ sub test_calendarevent_set_description
 }
 
 sub test_calendarevent_set_links
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1798,7 +1806,7 @@ sub test_calendarevent_set_links
 }
 
 sub test_calendarevent_set_locations
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1881,7 +1889,7 @@ sub test_calendarevent_set_locations
 }
 
 sub test_calendarevent_set_locations_single
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1925,7 +1933,7 @@ sub test_calendarevent_set_locations_single
 }
 
 sub test_calendarevent_set_recurrence
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1964,7 +1972,7 @@ sub test_calendarevent_set_recurrence
 }
 
 sub test_calendarevent_set_recurrenceoverrides
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2041,7 +2049,7 @@ sub test_calendarevent_set_recurrenceoverrides
 }
 
 sub test_calendarevent_set_participants
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2145,7 +2153,7 @@ sub test_calendarevent_set_participants
 }
 
 sub test_calendarevent_set_alerts
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2211,7 +2219,7 @@ sub test_calendarevent_set_alerts
 }
 
 sub test_calendarevent_set_participantid
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2256,7 +2264,7 @@ sub test_calendarevent_set_participantid
 
 
 sub test_calendarevent_set_isallday
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2305,7 +2313,7 @@ sub test_calendarevent_set_isallday
 }
 
 sub test_calendarevent_set_move
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2379,7 +2387,7 @@ sub test_calendarevent_set_move
 }
 
 sub test_calendarevent_set_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2540,7 +2548,7 @@ sub test_calendarevent_set_shared
 
 
 sub test_calendarevent_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2711,7 +2719,7 @@ sub test_calendarevent_changes
 }
 
 sub test_calendarevent_query
-:JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2841,7 +2849,7 @@ sub test_calendarevent_query
 }
 
 sub test_calendarevent_query_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3002,7 +3010,7 @@ sub test_calendarevent_query_shared
 }
 
 sub test_calendarevent_query_datetime
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3110,7 +3118,7 @@ sub test_calendarevent_query_datetime
 }
 
 sub test_calendarevent_query_date
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3239,7 +3247,7 @@ sub test_calendarevent_query_date
 }
 
 sub test_calendarevent_query_text
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3350,7 +3358,7 @@ sub test_calendarevent_query_text
 }
 
 sub test_calendarevent_query_unixepoch
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3393,7 +3401,7 @@ sub test_calendarevent_query_unixepoch
 
 
 sub test_calendarevent_set_caldav
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3521,7 +3529,7 @@ EOF
 }
 
 sub test_calendarevent_set_schedule_request
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3573,7 +3581,7 @@ sub test_calendarevent_set_schedule_request
 }
 
 sub test_calendarevent_set_schedule_reply
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3634,7 +3642,7 @@ sub test_calendarevent_set_schedule_reply
 }
 
 sub test_calendarevent_set_schedule_cancel
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3698,7 +3706,7 @@ sub test_calendarevent_set_schedule_cancel
 }
 
 sub test_misc_creationids
-:JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3733,7 +3741,7 @@ sub test_misc_creationids
 }
 
 sub test_misc_timezone_expansion
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -3773,7 +3781,7 @@ sub test_misc_timezone_expansion
 }
 
 sub test_calendarevent_set_uid
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/JMAPContacts.pm
+++ b/Cassandane/Cyrus/JMAPContacts.pm
@@ -79,7 +79,7 @@ sub set_up
 }
 
 sub test_contact_set_multicontact
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -127,7 +127,7 @@ sub test_contact_set_multicontact
 }
 
 sub test_contact_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -250,7 +250,7 @@ sub test_contact_changes
 }
 
 sub test_contact_changes_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -411,7 +411,7 @@ sub test_contact_changes_shared
 }
 
 sub test_contact_set_nickname
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -438,7 +438,7 @@ sub test_contact_set_nickname
 }
 
 sub test_contactgroup_set
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
 
     my ($self) = @_;
@@ -504,7 +504,7 @@ sub test_contactgroup_set
 }
 
 sub test_contact_query
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -677,7 +677,7 @@ sub test_contact_query
 
 
 sub test_contact_query_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -885,7 +885,7 @@ sub test_contact_query_shared
 }
 
 sub test_contactgroup_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1018,7 +1018,7 @@ sub test_contactgroup_changes
 }
 
 sub test_contactgroup_changes_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1188,7 +1188,7 @@ sub test_contactgroup_changes_shared
 }
 
 sub test_contact_set
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1502,7 +1502,7 @@ sub test_contact_set
 }
 
 sub test_contact_set_emaillabel
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1553,7 +1553,7 @@ sub test_contact_set_emaillabel
 
 
 sub test_contact_set_state
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1620,7 +1620,7 @@ sub test_contact_set_state
 }
 
 sub test_contact_set_importance_later
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1655,7 +1655,7 @@ sub test_contact_set_importance_later
 }
 
 sub test_contact_set_importance_upfront
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1690,7 +1690,7 @@ sub test_contact_set_importance_upfront
 }
 
 sub test_contact_set_importance_multiedit
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1725,7 +1725,7 @@ sub test_contact_set_importance_multiedit
 }
 
 sub test_contact_set_importance_zero_multi
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1760,7 +1760,7 @@ sub test_contact_set_importance_zero_multi
 }
 
 sub test_contact_set_importance_zero_byself
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1795,7 +1795,7 @@ sub test_contact_set_importance_zero_byself
 }
 
 sub test_misc_creationids
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1818,7 +1818,7 @@ sub test_misc_creationids
 }
 
 sub test_misc_categories
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1877,7 +1877,7 @@ EOF
 }
 
 sub test_contact_get_issue2292
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1903,7 +1903,7 @@ sub test_contact_get_issue2292
 }
 
 sub test_contactgroup_get_issue2292
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/JMAPContacts.pm
+++ b/Cassandane/Cyrus/JMAPContacts.pm
@@ -57,14 +57,18 @@ use charnames ':full';
 sub new
 {
     my ($class, @args) = @_;
+
     my $config = Cassandane::Config->default()->clone();
-    $config->set(caldav_realm => 'Cassandane');
-    $config->set(httpmodules => 'carddav jmap');
-    $config->set(httpallowcompress => 'no');
+    $config->set(caldav_realm => 'Cassandane',
+		 conversations => 'yes',
+		 httpmodules => 'carddav caldav jmap',
+		 httpallowcompress => 'no');
+
     return $class->SUPER::new({
-        adminstore => 1,
-        config => $config,
-        services => ['imap', 'http'],
+	config => $config,
+	jmap => 1,
+	adminstore => 1,
+	services => [ 'imap', 'http' ]
     }, @args);
 }
 
@@ -75,7 +79,7 @@ sub set_up
 }
 
 sub test_contact_set_multicontact
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -123,7 +127,7 @@ sub test_contact_set_multicontact
 }
 
 sub test_contact_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -246,7 +250,7 @@ sub test_contact_changes
 }
 
 sub test_contact_changes_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -407,7 +411,7 @@ sub test_contact_changes_shared
 }
 
 sub test_contact_set_nickname
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -434,7 +438,7 @@ sub test_contact_set_nickname
 }
 
 sub test_contactgroup_set
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
 
     my ($self) = @_;
@@ -500,7 +504,7 @@ sub test_contactgroup_set
 }
 
 sub test_contact_query
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -673,7 +677,7 @@ sub test_contact_query
 
 
 sub test_contact_query_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -881,7 +885,7 @@ sub test_contact_query_shared
 }
 
 sub test_contactgroup_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1014,7 +1018,7 @@ sub test_contactgroup_changes
 }
 
 sub test_contactgroup_changes_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1184,7 +1188,7 @@ sub test_contactgroup_changes_shared
 }
 
 sub test_contact_set
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1498,7 +1502,7 @@ sub test_contact_set
 }
 
 sub test_contact_set_emaillabel
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1549,7 +1553,7 @@ sub test_contact_set_emaillabel
 
 
 sub test_contact_set_state
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1616,7 +1620,7 @@ sub test_contact_set_state
 }
 
 sub test_contact_set_importance_later
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1651,7 +1655,7 @@ sub test_contact_set_importance_later
 }
 
 sub test_contact_set_importance_upfront
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1686,7 +1690,7 @@ sub test_contact_set_importance_upfront
 }
 
 sub test_contact_set_importance_multiedit
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1721,7 +1725,7 @@ sub test_contact_set_importance_multiedit
 }
 
 sub test_contact_set_importance_zero_multi
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1756,7 +1760,7 @@ sub test_contact_set_importance_zero_multi
 }
 
 sub test_contact_set_importance_zero_byself
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1791,7 +1795,7 @@ sub test_contact_set_importance_zero_byself
 }
 
 sub test_misc_creationids
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1814,7 +1818,7 @@ sub test_misc_creationids
 }
 
 sub test_misc_categories
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1873,7 +1877,7 @@ EOF
 }
 
 sub test_contact_get_issue2292
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1899,7 +1903,7 @@ sub test_contact_get_issue2292
 }
 
 sub test_contactgroup_get_issue2292
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/JMAPCore.pm
+++ b/Cassandane/Cyrus/JMAPCore.pm
@@ -75,7 +75,7 @@ sub new
 }
 
 sub test_settings
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -191,7 +191,7 @@ sub test_settings
 }
 
 sub test_blob_download
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -229,7 +229,7 @@ sub test_blob_download
 }
 
 sub test_creationids
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};

--- a/Cassandane/Cyrus/JMAPCore.pm
+++ b/Cassandane/Cyrus/JMAPCore.pm
@@ -59,11 +59,23 @@ use charnames ':full';
 sub new
 {
     my ($class, @args) = @_;
-    return $class->SUPER::new({}, @args);
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(caldav_realm => 'Cassandane',
+		 conversations => 'yes',
+		 httpmodules => 'carddav caldav jmap',
+		 httpallowcompress => 'no');
+
+    return $class->SUPER::new({
+	config => $config,
+	jmap => 1,
+	adminstore => 1,
+	services => [ 'imap', 'http' ]
+    }, @args);
 }
 
 sub test_settings
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -179,7 +191,7 @@ sub test_settings
 }
 
 sub test_blob_download
-:JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -217,7 +229,7 @@ sub test_blob_download
 }
 
 sub test_creationids
-:JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};

--- a/Cassandane/Cyrus/JMAPMail.pm
+++ b/Cassandane/Cyrus/JMAPMail.pm
@@ -102,7 +102,7 @@ sub getinbox
 }
 
 sub test_mailbox_get
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -180,7 +180,7 @@ sub test_mailbox_get
 }
 
 sub test_mailbox_get_specialuse
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -228,7 +228,7 @@ sub test_mailbox_get_specialuse
 }
 
 sub test_mailbox_get_properties
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -256,7 +256,7 @@ sub test_mailbox_get_properties
 }
 
 sub test_mailbox_get_ids
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -294,7 +294,7 @@ sub test_mailbox_get_ids
 }
 
 sub test_mailbox_get_nocalendars
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -329,7 +329,7 @@ sub test_mailbox_get_nocalendars
 }
 
 sub test_mailbox_get_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -390,7 +390,7 @@ sub test_mailbox_get_shared
 }
 
 sub test_mailbox_query
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -531,7 +531,7 @@ sub test_mailbox_query
 }
 
 sub test_mailbox_query_parentname
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -574,7 +574,7 @@ sub test_mailbox_query_parentname
 }
 
 sub test_mailbox_query_limit_zero
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -589,7 +589,7 @@ sub test_mailbox_query_limit_zero
 }
 
 sub test_mailbox_query_parentid_null
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -622,7 +622,7 @@ sub test_mailbox_query_parentid_null
 }
 
 sub test_mailbox_query_filteroperator
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     return;
@@ -697,7 +697,7 @@ sub test_mailbox_query_filteroperator
 }
 
 sub test_mailbox_query_issue2286
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -711,7 +711,7 @@ sub test_mailbox_query_issue2286
 }
 
 sub test_mailbox_querychanges
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -735,7 +735,7 @@ sub test_mailbox_querychanges
 }
 
 sub test_mailbox_set
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -817,7 +817,7 @@ sub test_mailbox_set
 }
 
 sub test_mailbox_get_shared_parents
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -855,7 +855,7 @@ sub test_mailbox_get_shared_parents
 }
 
 sub test_mailbox_set_name_missing
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -877,7 +877,7 @@ sub test_mailbox_set_name_missing
 
 
 sub test_mailbox_set_name_collision
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -980,7 +980,7 @@ sub test_mailbox_set_name_collision
 }
 
 sub test_mailbox_set_name_interop
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1036,7 +1036,7 @@ sub test_mailbox_set_name_interop
 }
 
 sub test_mailbox_set_name_unicode_nfc
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1068,7 +1068,7 @@ sub test_mailbox_set_name_unicode_nfc
 
 
 sub test_mailbox_set_role
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1203,7 +1203,7 @@ sub test_mailbox_set_role
 }
 
 sub test_mailbox_set_no_outbox_role
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1221,7 +1221,7 @@ sub test_mailbox_set_no_outbox_role
 
 
 sub test_mailbox_set_parent
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1315,7 +1315,7 @@ sub test_mailbox_set_parent
 }
 
 sub test_mailbox_set_parent_acl
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1348,7 +1348,7 @@ sub test_mailbox_set_parent_acl
 }
 
 sub test_mailbox_set_destroy_empty
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1417,7 +1417,7 @@ sub test_mailbox_set_destroy_empty
 }
 
 sub test_mailbox_set_destroy_removemsgs
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1474,7 +1474,7 @@ sub test_mailbox_set_destroy_removemsgs
 }
 
 sub test_mailbox_set_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1541,7 +1541,7 @@ sub test_mailbox_set_shared
 }
 
 sub test_mailbox_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1688,7 +1688,7 @@ sub test_mailbox_changes
 }
 
 sub test_mailbox_changes_counts
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1803,7 +1803,7 @@ sub test_mailbox_changes_counts
 
 
 sub test_mailbox_changes_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -1880,7 +1880,7 @@ sub defaultprops_for_email_get
 }
 
 sub test_email_get
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1982,7 +1982,7 @@ sub test_email_get
 }
 
 sub test_email_get_mimeencode
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2050,7 +2050,7 @@ sub test_email_get_mimeencode
 }
 
 sub test_email_get_multimailboxes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2091,7 +2091,7 @@ sub test_email_get_multimailboxes
 }
 
 sub test_email_get_body_both
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2141,7 +2141,7 @@ sub test_email_get_body_both
 }
 
 sub test_email_get_body_plain
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2175,7 +2175,7 @@ sub test_email_get_body_plain
 }
 
 sub test_email_get_body_html
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2209,7 +2209,7 @@ sub test_email_get_body_html
 }
 
 sub test_email_get_attachment_name
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2314,7 +2314,7 @@ sub test_email_get_attachment_name
 }
 
 sub test_email_get_body_notext
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2343,7 +2343,7 @@ sub test_email_get_body_notext
 
 
 sub test_email_get_preview
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2374,7 +2374,7 @@ sub test_email_get_preview
 }
 
 sub test_email_get_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2415,7 +2415,7 @@ sub test_email_get_shared
 }
 
 sub test_email_set_draft
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2489,7 +2489,7 @@ sub test_email_set_draft
 }
 
 sub test_email_set_issue2293
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2566,7 +2566,7 @@ sub test_email_set_issue2293
 }
 
 sub test_email_set_inreplyto
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2629,7 +2629,7 @@ sub test_email_set_inreplyto
 }
 
 sub test_email_set_attachedemails
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2697,7 +2697,7 @@ sub test_email_set_attachedemails
 }
 
 sub test_email_set_bodystructure
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2810,7 +2810,7 @@ sub test_email_set_bodystructure
 }
 
 sub test_email_set_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -2871,7 +2871,7 @@ sub test_email_set_shared
 }
 
 sub test_email_set_userkeywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2943,7 +2943,7 @@ sub test_email_set_userkeywords
 }
 
 sub test_misc_upload_zero
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2992,7 +2992,7 @@ sub test_misc_upload_zero
 }
 
 sub test_misc_upload
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3045,7 +3045,7 @@ sub test_misc_upload
 }
 
 sub test_misc_upload_multiaccount
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3068,7 +3068,7 @@ sub test_misc_upload_multiaccount
 }
 
 sub test_misc_upload_bin
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3117,7 +3117,7 @@ sub test_misc_upload_bin
 }
 
 sub test_misc_download
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3182,7 +3182,7 @@ sub download
 }
 
 sub test_blob_copy
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3244,7 +3244,7 @@ sub test_blob_copy
 }
 
 sub test_email_set_attachments
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3399,7 +3399,7 @@ sub test_email_set_attachments
 }
 
 sub test_email_set_flagged
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3437,7 +3437,7 @@ sub test_email_set_flagged
 }
 
 sub test_email_set_mailboxids
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3491,7 +3491,7 @@ sub test_email_set_mailboxids
 }
 
 sub test_email_get_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3568,7 +3568,7 @@ sub test_email_get_keywords
 }
 
 sub test_email_get_keywords_case_insensitive
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3601,7 +3601,7 @@ sub test_email_get_keywords_case_insensitive
 }
 
 sub test_email_set_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3733,7 +3733,7 @@ sub test_email_set_keywords
 }
 
 sub test_emailsubmission_set
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3785,7 +3785,7 @@ sub test_emailsubmission_set
 }
 
 sub test_emailsubmission_set_with_envelope
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3825,7 +3825,7 @@ sub test_emailsubmission_set_with_envelope
 }
 
 sub test_emailsubmission_set_issue2285
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3888,7 +3888,7 @@ sub test_emailsubmission_set_issue2285
 }
 
 sub test_emailsubmission_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3937,7 +3937,7 @@ sub test_emailsubmission_changes
 }
 
 sub test_emailsubmission_query
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3958,7 +3958,7 @@ sub test_emailsubmission_query
 }
 
 sub test_emailsubmission_querychanges
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3979,7 +3979,7 @@ sub test_emailsubmission_querychanges
 }
 
 sub test_email_set_move
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4039,7 +4039,7 @@ sub test_email_set_move
 }
 
 sub test_email_set_move_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4097,7 +4097,7 @@ sub test_email_set_move_keywords
 }
 
 sub test_email_set_update
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4152,7 +4152,7 @@ sub test_email_set_update
 }
 
 sub test_email_set_seen
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4191,7 +4191,7 @@ sub test_email_set_seen
 }
 
 sub test_email_set_destroy
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4267,7 +4267,7 @@ sub test_email_set_destroy
 }
 
 sub test_email_query
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4594,7 +4594,7 @@ sub test_email_query
 }
 
 sub test_email_query_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4947,7 +4947,7 @@ sub test_email_query_shared
 }
 
 sub test_email_query_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5045,7 +5045,7 @@ sub test_email_query_keywords
 }
 
 sub test_email_query_userkeywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5114,7 +5114,7 @@ sub test_email_query_userkeywords
 }
 
 sub test_email_query_threadkeywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5295,7 +5295,7 @@ sub test_email_query_threadkeywords
 }
 
 sub test_email_query_empty
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5315,7 +5315,7 @@ sub test_email_query_empty
 }
 
 sub test_email_query_collapse
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5367,7 +5367,7 @@ sub test_email_query_collapse
 }
 
 sub test_email_query_inmailbox_null
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5385,7 +5385,7 @@ sub test_email_query_inmailbox_null
 }
 
 sub test_misc_collapsethreads_issue2024
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5426,7 +5426,7 @@ sub test_misc_collapsethreads_issue2024
 }
 
 sub test_email_query_window
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5516,7 +5516,7 @@ sub test_email_query_window
 }
 
 sub test_email_query_long
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5560,7 +5560,7 @@ sub test_email_query_long
 }
 
 sub test_email_query_acl
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5619,7 +5619,7 @@ sub test_email_query_acl
 }
 
 sub test_email_query_unknown_mailbox
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5643,7 +5643,7 @@ sub test_email_query_unknown_mailbox
 
 
 sub test_searchsnippet_get
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5752,7 +5752,7 @@ sub test_searchsnippet_get
 }
 
 sub test_searchsnippet_get_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5815,7 +5815,7 @@ sub test_searchsnippet_get_shared
 }
 
 sub test_email_query_snippets
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -5900,7 +5900,7 @@ sub test_email_query_snippets
 }
 
 sub test_email_query_attachments
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6003,7 +6003,7 @@ sub test_email_query_attachments
 }
 
 sub test_email_query_attachmentname
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6062,7 +6062,7 @@ sub test_email_query_attachmentname
 }
 
 sub test_email_query_attachmenttype
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6162,7 +6162,7 @@ sub test_email_query_attachmenttype
 }
 
 sub test_thread_get
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -6269,7 +6269,7 @@ sub test_thread_get
 }
 
 sub test_identity_get
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6293,7 +6293,7 @@ sub test_identity_get
 }
 
 sub test_misc_emptyids
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -6320,7 +6320,7 @@ sub test_misc_emptyids
 }
 
 sub test_email_querychanges_basic
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6371,7 +6371,7 @@ sub test_email_querychanges_basic
 }
 
 sub test_email_querychanges_basic_collapse
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6424,7 +6424,7 @@ sub test_email_querychanges_basic_collapse
 }
 
 sub test_email_querychanges_basic_mb
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6477,7 +6477,7 @@ sub test_email_querychanges_basic_mb
 }
 
 sub test_email_querychanges_basic_mb_collapse
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6598,7 +6598,7 @@ sub test_email_querychanges_basic_mb_collapse
 }
 
 sub test_email_querychanges_skipdeleted
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6660,7 +6660,7 @@ sub test_email_querychanges_skipdeleted
 }
 
 sub test_email_querychanges_deletedcopy
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6723,7 +6723,7 @@ sub test_email_querychanges_deletedcopy
 }
 
 sub test_email_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6884,7 +6884,7 @@ sub test_email_changes
 }
 
 sub test_email_querychanges
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6922,7 +6922,7 @@ sub test_email_querychanges
 }
 
 sub test_email_querychanges_zerosince
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6960,7 +6960,7 @@ sub test_email_querychanges_zerosince
 
 
 sub test_email_querychanges_thread
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7038,7 +7038,7 @@ sub test_email_querychanges_thread
 }
 
 sub test_email_querychanges_order
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7097,7 +7097,7 @@ sub test_email_querychanges_order
 }
 
 sub test_email_querychanges_implementation
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7244,7 +7244,7 @@ sub test_email_querychanges_implementation
 }
 
 sub test_email_changes_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7333,7 +7333,7 @@ sub test_email_changes_shared
 }
 
 sub test_misc_upload_download822
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7359,7 +7359,7 @@ EOF
 }
 
 sub test_misc_upload_sametype
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7376,7 +7376,7 @@ sub test_misc_upload_sametype
 }
 
 sub test_misc_brokenrfc822_badendline
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7424,7 +7424,7 @@ EOF
 }
 
 sub test_email_import_zerobyte
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7472,7 +7472,7 @@ EOF
 
 
 sub test_email_import_setdate
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7532,7 +7532,7 @@ EOF
 }
 
 sub test_thread_get_onemsg
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -7601,7 +7601,7 @@ EOF
 }
 
 sub test_thread_changes
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my %exp;
@@ -7821,7 +7821,7 @@ sub test_thread_changes
 }
 
 sub test_email_import
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7919,7 +7919,7 @@ sub test_email_import
 }
 
 sub test_email_import_error
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7955,7 +7955,7 @@ sub test_email_import_error
 
 
 sub test_email_import_shared
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8001,7 +8001,7 @@ EOF
 }
 
 sub test_misc_refobjects_simple
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8036,7 +8036,7 @@ sub test_misc_refobjects_simple
 }
 
 sub test_email_import_no_keywords
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8073,7 +8073,7 @@ EOF
 }
 
 sub test_misc_refobjects_extended
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8114,7 +8114,7 @@ sub test_misc_refobjects_extended
 }
 
 sub test_email_set_patch
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8192,7 +8192,7 @@ sub test_email_set_patch
 }
 
 sub test_capability
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 
@@ -8222,7 +8222,7 @@ sub test_capability
 }
 
 sub test_misc_set_oldstate
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8276,7 +8276,7 @@ sub test_misc_set_oldstate
 }
 
 sub test_email_set_text_crlf
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8308,7 +8308,7 @@ sub test_email_set_text_crlf
 }
 
 sub test_email_set_text_split
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8338,7 +8338,7 @@ sub test_email_set_text_split
 }
 
 sub test_email_get_attachedemails
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8395,7 +8395,7 @@ sub test_email_get_attachedemails
 }
 
 sub test_email_get_maxbodyvaluebytes_utf8
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8444,7 +8444,7 @@ sub test_email_get_maxbodyvaluebytes_utf8
 }
 
 sub test_email_get_header_all
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8476,7 +8476,7 @@ sub test_email_get_header_all
 }
 
 sub test_email_set_nullheader
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8511,7 +8511,7 @@ sub test_email_set_nullheader
 }
 
 sub test_email_set_headers
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8653,7 +8653,7 @@ sub test_email_set_headers
 }
 
 sub test_email_download
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8699,7 +8699,7 @@ sub test_email_download
 }
 
 sub test_email_embedded_download
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8750,7 +8750,7 @@ sub test_email_embedded_download
 }
 
 sub test_blob_download
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8769,7 +8769,7 @@ sub test_blob_download
 }
 
 sub test_email_set_filename
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8845,7 +8845,7 @@ sub test_email_set_filename
 }
 
 sub test_email_get_size
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8868,7 +8868,7 @@ sub test_email_get_size
 }
 
 sub test_email_get_references
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8897,7 +8897,7 @@ sub test_email_get_references
 }
 
 sub test_email_get_groupaddr
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8936,7 +8936,7 @@ sub test_email_get_groupaddr
 }
 
 sub test_email_parse
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9010,7 +9010,7 @@ sub test_email_parse
 }
 
 sub test_email_parse_digest
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9052,7 +9052,7 @@ sub test_email_parse_digest
 }
 
 sub test_email_parse_blob822
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9080,7 +9080,7 @@ EOF
 }
 
 sub test_email_parse_notparsable
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9100,7 +9100,7 @@ EOF
 }
 
 sub test_email_get_bodystructure
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9323,7 +9323,7 @@ sub test_email_get_bodystructure
 }
 
 sub test_email_get_calendarevents
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9400,7 +9400,7 @@ sub test_email_get_calendarevents
 }
 
 sub test_email_set_blobencoding
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9473,7 +9473,7 @@ EOF
 }
 
 sub test_email_body_alternative_without_html
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9521,7 +9521,7 @@ sub test_email_body_alternative_without_html
 }
 
 sub test_mailbox_set_issue2377
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/JMAPMail.pm
+++ b/Cassandane/Cyrus/JMAPMail.pm
@@ -59,7 +59,19 @@ use charnames ':full';
 sub new
 {
     my ($class, @args) = @_;
-    return $class->SUPER::new({}, @args);
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(caldav_realm => 'Cassandane',
+		 conversations => 'yes',
+		 httpmodules => 'carddav caldav jmap',
+		 httpallowcompress => 'no');
+
+    return $class->SUPER::new({
+	config => $config,
+	jmap => 1,
+	adminstore => 1,
+	services => [ 'imap', 'http' ]
+    }, @args);
 }
 
 sub set_up
@@ -90,7 +102,7 @@ sub getinbox
 }
 
 sub test_mailbox_get
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -168,7 +180,7 @@ sub test_mailbox_get
 }
 
 sub test_mailbox_get_specialuse
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -216,7 +228,7 @@ sub test_mailbox_get_specialuse
 }
 
 sub test_mailbox_get_properties
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -244,7 +256,7 @@ sub test_mailbox_get_properties
 }
 
 sub test_mailbox_get_ids
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -282,7 +294,7 @@ sub test_mailbox_get_ids
 }
 
 sub test_mailbox_get_nocalendars
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -317,7 +329,7 @@ sub test_mailbox_get_nocalendars
 }
 
 sub test_mailbox_get_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -378,7 +390,7 @@ sub test_mailbox_get_shared
 }
 
 sub test_mailbox_query
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -519,7 +531,7 @@ sub test_mailbox_query
 }
 
 sub test_mailbox_query_parentname
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -562,7 +574,7 @@ sub test_mailbox_query_parentname
 }
 
 sub test_mailbox_query_limit_zero
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -577,7 +589,7 @@ sub test_mailbox_query_limit_zero
 }
 
 sub test_mailbox_query_parentid_null
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -610,7 +622,7 @@ sub test_mailbox_query_parentid_null
 }
 
 sub test_mailbox_query_filteroperator
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     return;
@@ -685,7 +697,7 @@ sub test_mailbox_query_filteroperator
 }
 
 sub test_mailbox_query_issue2286
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -699,7 +711,7 @@ sub test_mailbox_query_issue2286
 }
 
 sub test_mailbox_querychanges
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -723,7 +735,7 @@ sub test_mailbox_querychanges
 }
 
 sub test_mailbox_set
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -805,7 +817,7 @@ sub test_mailbox_set
 }
 
 sub test_mailbox_get_shared_parents
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -843,7 +855,7 @@ sub test_mailbox_get_shared_parents
 }
 
 sub test_mailbox_set_name_missing
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -865,7 +877,7 @@ sub test_mailbox_set_name_missing
 
 
 sub test_mailbox_set_name_collision
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -968,7 +980,7 @@ sub test_mailbox_set_name_collision
 }
 
 sub test_mailbox_set_name_interop
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1024,7 +1036,7 @@ sub test_mailbox_set_name_interop
 }
 
 sub test_mailbox_set_name_unicode_nfc
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1056,7 +1068,7 @@ sub test_mailbox_set_name_unicode_nfc
 
 
 sub test_mailbox_set_role
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1191,7 +1203,7 @@ sub test_mailbox_set_role
 }
 
 sub test_mailbox_set_no_outbox_role
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1209,7 +1221,7 @@ sub test_mailbox_set_no_outbox_role
 
 
 sub test_mailbox_set_parent
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1303,7 +1315,7 @@ sub test_mailbox_set_parent
 }
 
 sub test_mailbox_set_parent_acl
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1336,7 +1348,7 @@ sub test_mailbox_set_parent_acl
 }
 
 sub test_mailbox_set_destroy_empty
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1405,7 +1417,7 @@ sub test_mailbox_set_destroy_empty
 }
 
 sub test_mailbox_set_destroy_removemsgs
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1462,7 +1474,7 @@ sub test_mailbox_set_destroy_removemsgs
 }
 
 sub test_mailbox_set_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1529,7 +1541,7 @@ sub test_mailbox_set_shared
 }
 
 sub test_mailbox_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1676,7 +1688,7 @@ sub test_mailbox_changes
 }
 
 sub test_mailbox_changes_counts
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1791,7 +1803,7 @@ sub test_mailbox_changes_counts
 
 
 sub test_mailbox_changes_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -1868,7 +1880,7 @@ sub defaultprops_for_email_get
 }
 
 sub test_email_get
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -1970,7 +1982,7 @@ sub test_email_get
 }
 
 sub test_email_get_mimeencode
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2038,7 +2050,7 @@ sub test_email_get_mimeencode
 }
 
 sub test_email_get_multimailboxes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2079,7 +2091,7 @@ sub test_email_get_multimailboxes
 }
 
 sub test_email_get_body_both
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2129,7 +2141,7 @@ sub test_email_get_body_both
 }
 
 sub test_email_get_body_plain
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2163,7 +2175,7 @@ sub test_email_get_body_plain
 }
 
 sub test_email_get_body_html
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2197,7 +2209,7 @@ sub test_email_get_body_html
 }
 
 sub test_email_get_attachment_name
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2302,7 +2314,7 @@ sub test_email_get_attachment_name
 }
 
 sub test_email_get_body_notext
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2331,7 +2343,7 @@ sub test_email_get_body_notext
 
 
 sub test_email_get_preview
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2362,7 +2374,7 @@ sub test_email_get_preview
 }
 
 sub test_email_get_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2403,7 +2415,7 @@ sub test_email_get_shared
 }
 
 sub test_email_set_draft
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2477,7 +2489,7 @@ sub test_email_set_draft
 }
 
 sub test_email_set_issue2293
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2554,7 +2566,7 @@ sub test_email_set_issue2293
 }
 
 sub test_email_set_inreplyto
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2617,7 +2629,7 @@ sub test_email_set_inreplyto
 }
 
 sub test_email_set_attachedemails
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2685,7 +2697,7 @@ sub test_email_set_attachedemails
 }
 
 sub test_email_set_bodystructure
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2798,7 +2810,7 @@ sub test_email_set_bodystructure
 }
 
 sub test_email_set_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -2859,7 +2871,7 @@ sub test_email_set_shared
 }
 
 sub test_email_set_userkeywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2931,7 +2943,7 @@ sub test_email_set_userkeywords
 }
 
 sub test_misc_upload_zero
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -2980,7 +2992,7 @@ sub test_misc_upload_zero
 }
 
 sub test_misc_upload
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3033,7 +3045,7 @@ sub test_misc_upload
 }
 
 sub test_misc_upload_multiaccount
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3056,7 +3068,7 @@ sub test_misc_upload_multiaccount
 }
 
 sub test_misc_upload_bin
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3105,7 +3117,7 @@ sub test_misc_upload_bin
 }
 
 sub test_misc_download
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3170,7 +3182,7 @@ sub download
 }
 
 sub test_blob_copy
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3232,7 +3244,7 @@ sub test_blob_copy
 }
 
 sub test_email_set_attachments
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3387,7 +3399,7 @@ sub test_email_set_attachments
 }
 
 sub test_email_set_flagged
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3425,7 +3437,7 @@ sub test_email_set_flagged
 }
 
 sub test_email_set_mailboxids
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3479,7 +3491,7 @@ sub test_email_set_mailboxids
 }
 
 sub test_email_get_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3556,7 +3568,7 @@ sub test_email_get_keywords
 }
 
 sub test_email_get_keywords_case_insensitive
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3589,7 +3601,7 @@ sub test_email_get_keywords_case_insensitive
 }
 
 sub test_email_set_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3721,7 +3733,7 @@ sub test_email_set_keywords
 }
 
 sub test_emailsubmission_set
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3773,7 +3785,7 @@ sub test_emailsubmission_set
 }
 
 sub test_emailsubmission_set_with_envelope
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3813,7 +3825,7 @@ sub test_emailsubmission_set_with_envelope
 }
 
 sub test_emailsubmission_set_issue2285
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3876,7 +3888,7 @@ sub test_emailsubmission_set_issue2285
 }
 
 sub test_emailsubmission_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3925,7 +3937,7 @@ sub test_emailsubmission_changes
 }
 
 sub test_emailsubmission_query
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3946,7 +3958,7 @@ sub test_emailsubmission_query
 }
 
 sub test_emailsubmission_querychanges
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -3967,7 +3979,7 @@ sub test_emailsubmission_querychanges
 }
 
 sub test_email_set_move
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4027,7 +4039,7 @@ sub test_email_set_move
 }
 
 sub test_email_set_move_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4085,7 +4097,7 @@ sub test_email_set_move_keywords
 }
 
 sub test_email_set_update
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4140,7 +4152,7 @@ sub test_email_set_update
 }
 
 sub test_email_set_seen
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4179,7 +4191,7 @@ sub test_email_set_seen
 }
 
 sub test_email_set_destroy
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4255,7 +4267,7 @@ sub test_email_set_destroy
 }
 
 sub test_email_query
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4582,7 +4594,7 @@ sub test_email_query
 }
 
 sub test_email_query_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -4935,7 +4947,7 @@ sub test_email_query_shared
 }
 
 sub test_email_query_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5033,7 +5045,7 @@ sub test_email_query_keywords
 }
 
 sub test_email_query_userkeywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5102,7 +5114,7 @@ sub test_email_query_userkeywords
 }
 
 sub test_email_query_threadkeywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5283,7 +5295,7 @@ sub test_email_query_threadkeywords
 }
 
 sub test_email_query_empty
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5303,7 +5315,7 @@ sub test_email_query_empty
 }
 
 sub test_email_query_collapse
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5355,7 +5367,7 @@ sub test_email_query_collapse
 }
 
 sub test_email_query_inmailbox_null
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5373,7 +5385,7 @@ sub test_email_query_inmailbox_null
 }
 
 sub test_misc_collapsethreads_issue2024
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5414,7 +5426,7 @@ sub test_misc_collapsethreads_issue2024
 }
 
 sub test_email_query_window
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5504,7 +5516,7 @@ sub test_email_query_window
 }
 
 sub test_email_query_long
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5548,7 +5560,7 @@ sub test_email_query_long
 }
 
 sub test_email_query_acl
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5607,7 +5619,7 @@ sub test_email_query_acl
 }
 
 sub test_email_query_unknown_mailbox
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5631,7 +5643,7 @@ sub test_email_query_unknown_mailbox
 
 
 sub test_searchsnippet_get
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5740,7 +5752,7 @@ sub test_searchsnippet_get
 }
 
 sub test_searchsnippet_get_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5803,7 +5815,7 @@ sub test_searchsnippet_get_shared
 }
 
 sub test_email_query_snippets
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -5888,7 +5900,7 @@ sub test_email_query_snippets
 }
 
 sub test_email_query_attachments
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -5991,7 +6003,7 @@ sub test_email_query_attachments
 }
 
 sub test_email_query_attachmentname
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6050,7 +6062,7 @@ sub test_email_query_attachmentname
 }
 
 sub test_email_query_attachmenttype
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6150,7 +6162,7 @@ sub test_email_query_attachmenttype
 }
 
 sub test_thread_get
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -6257,7 +6269,7 @@ sub test_thread_get
 }
 
 sub test_identity_get
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6281,7 +6293,7 @@ sub test_identity_get
 }
 
 sub test_misc_emptyids
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -6308,7 +6320,7 @@ sub test_misc_emptyids
 }
 
 sub test_email_querychanges_basic
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6359,7 +6371,7 @@ sub test_email_querychanges_basic
 }
 
 sub test_email_querychanges_basic_collapse
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6412,7 +6424,7 @@ sub test_email_querychanges_basic_collapse
 }
 
 sub test_email_querychanges_basic_mb
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6465,7 +6477,7 @@ sub test_email_querychanges_basic_mb
 }
 
 sub test_email_querychanges_basic_mb_collapse
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6586,7 +6598,7 @@ sub test_email_querychanges_basic_mb_collapse
 }
 
 sub test_email_querychanges_skipdeleted
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6648,7 +6660,7 @@ sub test_email_querychanges_skipdeleted
 }
 
 sub test_email_querychanges_deletedcopy
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6711,7 +6723,7 @@ sub test_email_querychanges_deletedcopy
 }
 
 sub test_email_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6872,7 +6884,7 @@ sub test_email_changes
 }
 
 sub test_email_querychanges
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6910,7 +6922,7 @@ sub test_email_querychanges
 }
 
 sub test_email_querychanges_zerosince
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -6948,7 +6960,7 @@ sub test_email_querychanges_zerosince
 
 
 sub test_email_querychanges_thread
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7026,7 +7038,7 @@ sub test_email_querychanges_thread
 }
 
 sub test_email_querychanges_order
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7085,7 +7097,7 @@ sub test_email_querychanges_order
 }
 
 sub test_email_querychanges_implementation
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7232,7 +7244,7 @@ sub test_email_querychanges_implementation
 }
 
 sub test_email_changes_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7321,7 +7333,7 @@ sub test_email_changes_shared
 }
 
 sub test_misc_upload_download822
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7347,7 +7359,7 @@ EOF
 }
 
 sub test_misc_upload_sametype
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7364,7 +7376,7 @@ sub test_misc_upload_sametype
 }
 
 sub test_misc_brokenrfc822_badendline
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7412,7 +7424,7 @@ EOF
 }
 
 sub test_email_import_zerobyte
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7460,7 +7472,7 @@ EOF
 
 
 sub test_email_import_setdate
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7520,7 +7532,7 @@ EOF
 }
 
 sub test_thread_get_onemsg
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -7589,7 +7601,7 @@ EOF
 }
 
 sub test_thread_changes
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my %exp;
@@ -7809,7 +7821,7 @@ sub test_thread_changes
 }
 
 sub test_email_import
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7907,7 +7919,7 @@ sub test_email_import
 }
 
 sub test_email_import_error
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7943,7 +7955,7 @@ sub test_email_import_error
 
 
 sub test_email_import_shared
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -7989,7 +8001,7 @@ EOF
 }
 
 sub test_misc_refobjects_simple
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8024,7 +8036,7 @@ sub test_misc_refobjects_simple
 }
 
 sub test_email_import_no_keywords
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8061,7 +8073,7 @@ EOF
 }
 
 sub test_misc_refobjects_extended
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8102,7 +8114,7 @@ sub test_misc_refobjects_extended
 }
 
 sub test_email_set_patch
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8180,7 +8192,7 @@ sub test_email_set_patch
 }
 
 sub test_capability
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 
@@ -8210,7 +8222,7 @@ sub test_capability
 }
 
 sub test_misc_set_oldstate
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8264,7 +8276,7 @@ sub test_misc_set_oldstate
 }
 
 sub test_email_set_text_crlf
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8296,7 +8308,7 @@ sub test_email_set_text_crlf
 }
 
 sub test_email_set_text_split
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8326,7 +8338,7 @@ sub test_email_set_text_split
 }
 
 sub test_email_get_attachedemails
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8383,7 +8395,7 @@ sub test_email_get_attachedemails
 }
 
 sub test_email_get_maxbodyvaluebytes_utf8
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8432,7 +8444,7 @@ sub test_email_get_maxbodyvaluebytes_utf8
 }
 
 sub test_email_get_header_all
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8464,7 +8476,7 @@ sub test_email_get_header_all
 }
 
 sub test_email_set_nullheader
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8499,7 +8511,7 @@ sub test_email_set_nullheader
 }
 
 sub test_email_set_headers
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8641,7 +8653,7 @@ sub test_email_set_headers
 }
 
 sub test_email_download
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8687,7 +8699,7 @@ sub test_email_download
 }
 
 sub test_email_embedded_download
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8738,7 +8750,7 @@ sub test_email_embedded_download
 }
 
 sub test_blob_download
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8757,7 +8769,7 @@ sub test_blob_download
 }
 
 sub test_email_set_filename
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8833,7 +8845,7 @@ sub test_email_set_filename
 }
 
 sub test_email_get_size
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8856,7 +8868,7 @@ sub test_email_get_size
 }
 
 sub test_email_get_references
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8885,7 +8897,7 @@ sub test_email_get_references
 }
 
 sub test_email_get_groupaddr
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8924,7 +8936,7 @@ sub test_email_get_groupaddr
 }
 
 sub test_email_parse
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -8998,7 +9010,7 @@ sub test_email_parse
 }
 
 sub test_email_parse_digest
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9040,7 +9052,7 @@ sub test_email_parse_digest
 }
 
 sub test_email_parse_blob822
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9068,7 +9080,7 @@ EOF
 }
 
 sub test_email_parse_notparsable
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9088,7 +9100,7 @@ EOF
 }
 
 sub test_email_get_bodystructure
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9311,7 +9323,7 @@ sub test_email_get_bodystructure
 }
 
 sub test_email_get_calendarevents
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9388,7 +9400,7 @@ sub test_email_get_calendarevents
 }
 
 sub test_email_set_blobencoding
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9461,7 +9473,7 @@ EOF
 }
 
 sub test_email_body_alternative_without_html
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -9509,7 +9521,7 @@ sub test_email_body_alternative_without_html
 }
 
 sub test_mailbox_set_issue2377
-    :JMAP :min_version_3_1
+    :min_version_3_1
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/Replication.pm
+++ b/Cassandane/Cyrus/Replication.pm
@@ -444,6 +444,7 @@ sub assert_sieve_matches
 }
 
 sub test_sieve_replication
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -487,6 +488,7 @@ EOF
 }
 
 sub test_sieve_replication_exists
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -531,6 +533,7 @@ EOF
 }
 
 sub test_sieve_replication_different
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -592,6 +595,7 @@ EOF
 }
 
 sub test_sieve_replication_stale
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -657,6 +661,7 @@ EOF
 }
 
 sub test_sieve_replication_delete_unactivate
+    :needs_component_sieve
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/Cassandane/Cyrus/SearchFuzzy.pm
@@ -61,7 +61,7 @@ sub set_up
     my ($self) = @_;
     $self->SUPER::set_up();
 
-    if (not $self->{instance}->{buildinfo}->{search}->{xapian}) {
+    if (not $self->{instance}->{buildinfo}->get('search', 'xapian')) {
         xlog "No xapian support enabled. Skipping tests.";
         return;
     }
@@ -71,7 +71,7 @@ sub set_up
     # if using our fork of xapian, or "none" if the Cyrus being tested isn't
     # new enough to know the difference.
     $self->{xapian_flavor} =
-        $self->{instance}->{buildinfo}->{search}->{xapian_flavor} || "none";
+        $self->{instance}->{buildinfo}->get('search', 'xapian_flavor') || "none";
 
     xlog "Xapian flavor '$self->{xapian_flavor}' detected.\n";
 

--- a/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/Cassandane/Cyrus/SearchFuzzy.pm
@@ -61,12 +61,6 @@ sub set_up
     my ($self) = @_;
     $self->SUPER::set_up();
 
-    if (not $self->{instance}->{buildinfo}->get('search', 'xapian')) {
-        xlog "No xapian support enabled. Skipping tests.";
-        return;
-    }
-    $self->{test_fuzzy_search} = 1;
-
     # This will be "vanilla" if using a standard/distro xapian, "cyruslibs"
     # if using our fork of xapian, or "none" if the Cyrus being tested isn't
     # new enough to know the difference.
@@ -140,6 +134,7 @@ sub create_testmessages
 }
 
 sub test_copy_messages
+    :needs_search_xapian
 {
     my ($self) = @_;
 
@@ -155,10 +150,9 @@ sub test_copy_messages
 }
 
 sub test_stem_verbs
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
     $self->create_testmessages();
 
     my $talk = $self->{store}->get_client();
@@ -189,10 +183,9 @@ sub test_stem_verbs
 }
 
 sub test_stem_any
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
     $self->create_testmessages();
 
     my $talk = $self->{store}->get_client();
@@ -218,10 +211,9 @@ sub test_stem_any
 }
 
 sub test_snippet_wildcard
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     # Set up Xapian database
     xlog "Generate and index test messages";
@@ -267,10 +259,9 @@ sub test_snippet_wildcard
 }
 
 sub test_mix_fuzzy_and_nonfuzzy
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
     $self->create_testmessages();
     my $talk = $self->{store}->get_client();
 
@@ -286,7 +277,7 @@ sub test_mix_fuzzy_and_nonfuzzy
 }
 
 sub test_weird_crasher
-    :Conversations :min_version_3_0
+    :Conversations :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
     return if not $self->{test_fuzzy_search};
@@ -303,10 +294,9 @@ sub test_weird_crasher
 }
 
 sub test_stopwords
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     # This test assumes that "the" is a stopword and is configured with
     # the search_stopword_path in cassandane.ini. If the option is not
@@ -368,10 +358,9 @@ sub test_stopwords
 }
 
 sub test_normalize_snippets
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     # Set up test message with funny characters
     my $body = "foo gären советской diĝir naïve léger";
@@ -417,10 +406,9 @@ sub test_normalize_snippets
 }
 
 sub test_skipdiacrit
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     # Set up test messages
     my $body = "Die Trauben gären.";
@@ -469,10 +457,9 @@ sub test_skipdiacrit
 }
 
 sub test_snippets_termcover
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     my $body =
     "The 'charset' portion of an 'encoded-word' specifies the character ".
@@ -553,10 +540,9 @@ sub test_snippets_termcover
 }
 
 sub test_cjk_words
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     xlog "Generate and index test messages.";
 
@@ -635,10 +621,9 @@ sub test_cjk_words
 }
 
 sub test_subject_isutf8
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     xlog "Generate and index test messages.";
     # that's: "nuff réunion critères duff"
@@ -699,9 +684,9 @@ sub test_subject_isutf8
 }
 
 sub test_noindex_multipartheaders
+    :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     my $talk = $self->{store}->get_client();
 
@@ -771,9 +756,9 @@ sub test_noindex_multipartheaders
 }
 
 sub test_xattachmentname
+    :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     my $talk = $self->{store}->get_client();
 
@@ -825,10 +810,9 @@ sub test_xattachmentname
 
 
 sub test_xapianv2
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     my $talk = $self->{store}->get_client();
 
@@ -906,10 +890,9 @@ sub test_xapianv2
 }
 
 sub test_snippets_escapehtml
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     xlog "Generate and index test messages.";
     $self->make_message("Test1 subject with an unescaped & in it",
@@ -953,10 +936,9 @@ sub test_snippets_escapehtml
 }
 
 sub test_search_exactmatch
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     xlog "Generate and index test messages.";
     $self->make_message("test1",
@@ -995,10 +977,9 @@ sub test_search_exactmatch
 }
 
 sub test_search_subjectsnippet
-    :min_version_3_0
+    :min_version_3_0 :needs_search_xapian
 {
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     xlog "Generate and index test messages.";
     $self->make_message("[plumbing] Re: log server v0 live",
@@ -1036,7 +1017,7 @@ sub test_search_subjectsnippet
 }
 
 sub test_audit_unindexed
-    :min_version_3_1
+    :min_version_3_1 :needs_component_jmap
 {
     # This test does some sneaky things to cyrus.indexed.db to force squatter
     # report audit errors. It assumes a specific format for cyrus.indexed.db
@@ -1044,7 +1025,6 @@ sub test_audit_unindexed
     # As such, it's likely to break for internal changes.
 
     my ($self) = @_;
-    return if not $self->{test_fuzzy_search};
 
     my $talk = $self->{store}->get_client();
 

--- a/Cassandane/Cyrus/Sieve.pm
+++ b/Cassandane/Cyrus/Sieve.pm
@@ -205,7 +205,9 @@ sub compile_sieve_script
     return $self->$meth($name, $script);
 }
 
-sub test_vacation_with_following_rules {
+sub test_vacation_with_following_rules
+    :needs_component_sieve
+{
     my ($self) = @_;
 
     my $target = "INBOX.target";
@@ -246,6 +248,7 @@ EOF
 }
 
 sub test_deliver
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -285,6 +288,7 @@ EOF
 
 sub test_deliver_specialuse
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -320,6 +324,7 @@ EOF
 
 sub test_deliver_compile
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -429,6 +434,7 @@ sub badscript_common
 }
 
 sub test_badscript_sievec
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -438,6 +444,7 @@ sub test_badscript_sievec
 }
 
 sub test_badscript_timsieved
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -447,6 +454,7 @@ sub test_badscript_timsieved
 }
 
 sub test_dup_keep_keep
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -474,6 +482,7 @@ EOF
 # tested for here.
 
 sub test_dup_keep_fileinto
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -497,6 +506,7 @@ EOF
 
 sub test_deliver_fileinto_dot
     :UnixHierarchySep
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -543,6 +553,7 @@ EOF
 # on shared mailboxes in 2.5.
 sub XXXtest_shared_delivery_addflag
     :Admin
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -594,6 +605,7 @@ EOF
 
 sub test_rfc5490_create
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -645,6 +657,7 @@ EOF
 
 sub test_rfc5490_mailboxexists
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -701,6 +714,7 @@ EOF
 
 sub test_rfc5490_mailboxexists_variables
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -758,6 +772,7 @@ EOF
 
 sub test_rfc5490_metadata
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -812,6 +827,7 @@ EOF
 
 sub test_rfc5490_metadata_matches
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -869,6 +885,7 @@ EOF
 
 sub test_rfc5490_metadataexists
     :min_version_3_0 :AnnotationAllowUndefined
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -923,6 +940,7 @@ EOF
 
 sub test_rfc5490_servermetadata
     :min_version_3_0 :AnnotationAllowUndefined
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -981,6 +999,7 @@ EOF
 
 sub test_rfc5490_servermetadataexists
     :min_version_3_0 :AnnotationAllowUndefined
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1037,6 +1056,7 @@ EOF
 
 sub test_variables_basic
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1092,6 +1112,7 @@ EOF
 
 sub test_sieve_setflag
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1132,6 +1153,7 @@ EOF
 
 sub test_variables_regex
     :min_version_3_0
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1186,6 +1208,7 @@ EOF
 }
 
 sub test_nested_tests_and_discard
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1213,6 +1236,7 @@ EOF
 
 sub test_editheader
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1248,6 +1272,7 @@ EOF
 
 sub test_duplicate
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1295,6 +1320,7 @@ EOF
 
 sub test_ereject
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1320,6 +1346,7 @@ EOF
 
 sub test_specialuse_exists
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1376,6 +1403,7 @@ EOF
 
 sub test_specialuse
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1407,6 +1435,7 @@ EOF
 
 sub test_specialuse_create
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1434,6 +1463,7 @@ EOF
 
 sub test_vacation_with_fcc
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -1477,6 +1507,7 @@ EOF
 
 sub test_github_issue_complex_variables
     :min_version_3_1
+    :needs_component_sieve
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -97,6 +97,7 @@ sub new
 	adminstore => 0,
 	gen => 1,
 	deliver => 0,
+	jmap => 0,
     };
     map {
 	$want->{$_} = delete $params->{$_}
@@ -232,18 +233,6 @@ magic(MagicPlus => sub {
 magic(FastMailSharing => sub {
     shift->config_set('fastmailsharing' => 'true');
 });
-magic(JMAP => sub {
-    my $self = shift;
-    $self->want('jmap');
-    $self->want('adminstore');
-    $self->want('services' => [ 'imap', 'http' ]);
-    $self->config_set(caldav_realm => 'Cassandane');
-    $self->config_set(conversations => 'yes');
-    $self->config_set(httpmodules => 'carddav caldav jmap');
-    $self->config_set(httpallowcompress => 'no');
-});
-
-
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -127,42 +127,6 @@ sub new
     return $self;
 }
 
-sub list_tests
-{
-    my ($class) = @_;
-
-    my %tests;
-    @tests{$class->SUPER::list_tests()} = undef;
-
-    # filter the list for tests that require cyr_buildinfo features
-    # which aren't currently enabled
-    #
-    # XXX could probably do the skip_version stuff here too actually
-    foreach my $name (keys %tests) {
-	my $sub = $class->can($name);
-	if (defined $sub) {
-	    foreach my $a (attributes::get($sub)) {
-		my $m = lc($a);
-		next if $a !~ m/^needs_(\w+)_([\w_]+)$/;
-		xlog "found attributed test: $name $a";
-
-		my $buildinfo = Cassandane::BuildInfo->new();
-
-		if (not $buildinfo) {
-		    xlog "Cyrus build info unreadable, " .
-			 "cannot skip tests for missing features";
-		}
-		elsif (not $buildinfo->get($1, $2)) {
-		    xlog "$1.$2 not enabled, $name will be skipped";
-		    delete $tests{$name};
-		}
-	    }
-	}
-    }
-
-    return sort keys %tests;
-}
-
 # will magically cause some special actions to be taken during test
 # setup.  This used to be a horrible hack to enable a replica instance
 # if the test name contained the word "replication", but now it's more

--- a/Cassandane/Cyrus/TesterJMAP.pm
+++ b/Cassandane/Cyrus/TesterJMAP.pm
@@ -63,6 +63,11 @@ sub cyrus_version_supports_jmap
 
     return 0 if ($maj < 3);  # not supported before 3.x
     return 0 if ($maj == 3 && $min == 0); # not supported in 3.0.x
+
+    # not supported if configured out
+    my $buildinfo = Cassandane::BuildInfo->new();
+    return 0 if not $buildinfo->get('component', 'jmap');
+
     return 1; # supported in everything newer
 }
 

--- a/testrunner.pl
+++ b/testrunner.pl
@@ -108,28 +108,27 @@ my @names;
     };
 };
 
-
 my %runners =
 (
     tap => sub
     {
 	my ($plan, $fh) = @_;
 	my $runner = Cassandane::Unit::Runner->new($fh);
-	$runner->filter('x', 'skip_version');
+	$runner->filter('x', 'skip_version', 'skip_missing_features');
 	return $runner->do_run($plan, 0);
     },
     pretty => sub
     {
 	my ($plan, $fh) = @_;
 	my $runner = Cassandane::Unit::RunnerPretty->new({}, $fh);
-	$runner->filter('x', 'skip_version');
+	$runner->filter('x', 'skip_version', 'skip_missing_features');
 	return $runner->do_run($plan, 0);
     },
     prettier => sub
     {
 	my ($plan, $fh) = @_;
 	my $runner = Cassandane::Unit::RunnerPretty->new({quiet=>1}, $fh);
-	$runner->filter('x', 'skip_version');
+	$runner->filter('x', 'skip_version', 'skip_missing_features');
 	return $runner->do_run($plan, 0);
     },
 );


### PR DESCRIPTION
Putting this in as a PR mainly to make sure it doesn't break for @jasontibbitts before I merge it down.