### PR TITLE
JMAPTestSuite: Don't override search/data partitions

### DIFF
--- a/Cassandane/Cyrus/JMAPTestSuite.pm
+++ b/Cassandane/Cyrus/JMAPTestSuite.pm
@@ -50,7 +50,6 @@ use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Cassini;
-use File::Temp qw(tempdir);
 
 my $basedir;
 my $binary;
@@ -103,9 +102,6 @@ sub new
     $config->set(search_batchsize => 8192);
     $config->set(defaultpartition => 'default');
     $config->set(defaultsearchtier => 't1');
-
-    $config->set('partition-default' => tempdir(CLEANUP => 1));
-    $config->set('t1searchpartition-default' => tempdir(CLEANUP => 1));
 
     $config->set('sync_log' => 'on');
     $config->set('sync_log_channels' => 'squatter');


### PR DESCRIPTION
These get filled in anyway for us and they stay around
after a test run so that you can look at the raw data.

By using tempdir(), we were mistakenly cleaning up these
directories after each test run. Oops.