### PR TITLE
Server annotation replication

### DIFF
--- a/Cassandane/Cyrus/Metadata.pm
+++ b/Cassandane/Cyrus/Metadata.pm
@@ -651,6 +651,216 @@ sub test_motd
 }
 
 #
+# Test the /shared/foobar server annotation replicates correctly
+#
+sub test_shared_global_annot_replication
+    :Replication :SyncLog :AnnotationAllowUndefined
+{
+    my ($self) = @_;
+
+    xlog $self, "testing /shared/foobar";
+
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+
+    $self->assert_not_null($self->{replica});
+
+    my $imaptalk = $self->{master_store}->get_client();
+
+    my $res;
+    my $entry = '/shared/foobar';
+    my $value1 = "Hello World this is a value - with a random annot";
+
+    xlog $self, "initial value is NIL";
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_deep_equals({
+        "" => { $entry => undef }
+    }, $res);
+
+    xlog $self, "cannot set the value as ordinary user";
+    $imaptalk->setmetadata("", $entry, $value1);
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert($imaptalk->get_last_error() =~ m/permission denied/i);
+
+    xlog $self, "can set the value as admin";
+    $imaptalk = $self->{adminstore}->get_client();
+    $imaptalk->setmetadata("", $entry, $value1);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    xlog $self, "can get the set value back";
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $expected = {
+            "" => { $entry => $value1 }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    $self->{adminstore}->disconnect();
+    $imaptalk = $self->{adminstore}->get_client();
+
+    xlog $self, "the annot gives the same value in the new connection";
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $expected = {
+            "" => { $entry => $value1 }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    xlog $self, "replica value is NIL";
+    $imaptalk = $self->{replica_store}->get_client();
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_deep_equals({
+        "" => { $entry => undef }
+    }, $res);
+
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+
+    xlog $self, "the annot gives the same value on the replica";
+    $imaptalk = $self->{replica_store}->get_client();
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $expected = {
+            "" => { $entry => $value1 }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    xlog $self, "can delete value";
+    $imaptalk = $self->{adminstore}->get_client();
+    $imaptalk->setmetadata("", $entry, undef);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $expected = {
+            "" => { $entry => undef }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    xlog $self, "run replication to clear annot";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+
+    xlog $self, "replica value is NIL";
+    $imaptalk = $self->{replica_store}->get_client();
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_deep_equals({
+        "" => { $entry => undef }
+    }, $res);
+}
+
+#
+# Test the /private/foobar server annotation replicates correctly
+#
+sub test_private_global_annot_replication
+    :Replication :SyncLog :AnnotationAllowUndefined
+{
+    my ($self) = @_;
+
+    xlog $self, "testing /private/foobar";
+
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+
+    $self->assert_not_null($self->{replica});
+
+    my $imaptalk = $self->{master_store}->get_client();
+
+    my $res;
+    my $entry = '/private/foobar';
+    my $value1 = "Hello World this is a value - with a random annot";
+
+    xlog $self, "initial value is NIL";
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_deep_equals({
+        "" => { $entry => undef }
+    }, $res);
+
+    xlog $self, "can set the value as ordinary user";
+    $imaptalk->setmetadata("", $entry, $value1);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    xlog $self, "can get the set value back";
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $expected = {
+            "" => { $entry => $value1 }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    $self->{master_store}->disconnect();
+    $imaptalk = $self->{master_store}->get_client();
+
+    xlog $self, "the annot gives the same value in the new connection";
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $expected = {
+            "" => { $entry => $value1 }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    xlog $self, "replica value is NIL";
+    $imaptalk = $self->{replica_store}->get_client();
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_deep_equals({
+        "" => { $entry => undef }
+    }, $res);
+
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+
+    xlog $self, "the annot gives the same value on the replica";
+    $imaptalk = $self->{replica_store}->get_client();
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $expected = {
+            "" => { $entry => $value1 }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    xlog $self, "can delete value";
+    $imaptalk = $self->{master_store}->get_client();
+    $imaptalk->setmetadata("", $entry, undef);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $expected = {
+            "" => { $entry => undef }
+    };
+    $self->assert_deep_equals($expected, $res);
+
+    xlog $self, "run replication to clear annot";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+
+    xlog $self, "replica value is NIL";
+    $imaptalk = $self->{replica_store}->get_client();
+    $res = $imaptalk->getmetadata("", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_deep_equals({
+        "" => { $entry => undef }
+    }, $res);
+}
+
+#
 # Test the /shared/vendor/cmu/cyrus-imapd/size annotation
 # which reports the total byte count of the RFC822 message
 # sizes in the mailbox.

--- a/Cassandane/Cyrus/Rename.pm
+++ b/Cassandane/Cyrus/Rename.pm
@@ -562,12 +562,9 @@ sub test_rename_user
 }
 
 sub test_rename_deepuser
-    :AllowMoves :Replication :NoStartInstances
+    :AllowMoves :Replication :SyncLog
 {
     my ($self) = @_;
-
-    $self->{instance}->{config}->set('sync_log' => 1);
-    $self->_start_instances();
 
     my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
 
@@ -640,12 +637,9 @@ sub test_rename_paths
 }
 
 sub test_rename_deepuser_unixhs
-    :AllowMoves :Replication :NoStartInstances :UnixHierarchySep
+    :AllowMoves :Replication :SyncLog :UnixHierarchySep
 {
     my ($self) = @_;
-
-    $self->{instance}->{config}->set('sync_log' => 1);
-    $self->_start_instances();
 
     my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
 

--- a/Cassandane/Cyrus/Replication.pm
+++ b/Cassandane/Cyrus/Replication.pm
@@ -1840,12 +1840,9 @@ sub test_sync_log_mailbox_with_spaces
 }
 
 sub test_intermediate_rename
-    :AllowMoves :Replication :NoStartInstances :DelayedDelete :min_version_3_3
+    :AllowMoves :Replication :SyncLog :DelayedDelete :min_version_3_3
 {
     my ($self) = @_;
-
-    $self->{instance}->{config}->set('sync_log' => 1);
-    $self->_start_instances();
 
     my $mtalk = $self->{master_store}->get_client();
 
@@ -1869,12 +1866,9 @@ sub test_intermediate_rename
 }
 
 sub test_clean_remote_shutdown_while_rolling
-    :CSyncReplication :NoStartInstances :min_version_3_5
+    :CSyncReplication :SyncLog :min_version_3_5
 {
     my ($self) = @_;
-
-    $self->{instance}->{config}->set('sync_log' => 1);
-    $self->_start_instances();
 
     my $mtalk = $self->{master_store}->get_client();
 

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -192,6 +192,9 @@ magic(ReverseACLs => sub {
 magic(RightNow => sub {
     shift->config_set(sync_rightnow_channel => '""');
 });
+magic(SyncLog => sub {
+    shift->config_set(sync_log => 1);
+});
 magic(Replication => sub { shift->want('replica'); });
 magic(CSyncReplication => sub {
     my ($self) = @_;


### PR DESCRIPTION
This is the tests for the related issue that I'm about to post an MR for.  Replication of server-level annotations wasn't working.  Also, this set of tests found a permissions bug for shared arbitrary annotations: https://github.com/cyrusimap/cyrus-imapd/pull/3456