### PR TITLE
Add run_dbcommand logic ported from Fastmail code

### DIFF
--- a/Cassandane/Cyrus/Metadata.pm
+++ b/Cassandane/Cyrus/Metadata.pm
@@ -207,7 +207,7 @@ sub list_uids
         $store->read_begin();
         while (my $msg = $store->read_message())
         {
-        push(@uids, $msg->{uid});
+        push(@uids, $msg->uid);
         }
         $store->read_end();
 

--- a/Cassandane/Cyrus/Metadata.pm
+++ b/Cassandane/Cyrus/Metadata.pm
@@ -2888,7 +2888,7 @@ sub test_cvt_cyrusdb
     my $global_db = "$basedir/conf/annotations.db";
     my $global_flat = "$basedir/xann.txt";
     my $format = $self->{instance}->{config}->get('annotation_db');
-    $format = $format // 'skiplist';
+    $format = $format // 'twoskip';
 
     $self->assert(( ! -f $global_flat ));
     $self->{instance}->run_command({ cyrus => 1 },

--- a/Cassandane/Cyrus/Metadata.pm
+++ b/Cassandane/Cyrus/Metadata.pm
@@ -104,40 +104,6 @@ sub make_message_pair
     return ($msg0, $msg1);
 }
 
-# Undo the binary escaping used by cvt_cyrusdb, which uses \xff as the
-# escape character and escapes \0 \t \r \n and \xff.  We need to do this
-# because both the key and value in the annotations DB use \0 as field
-# separators and we need to parse them correctly.
-sub unescape
-{
-    my ($s) = @_;
-    my $r = '';
-
-    for (;;)
-    {
-        my  ($pre, $byte, $post) =
-                ($s =~ m/^([\0-\xfe]*)\xff([\x80-\xff])(.*)$/);
-        last if !defined $byte;
-
-        $r .= $pre;
-        if ($byte eq '\xff')
-        {
-            $r .= '\xff';
-        }
-        else
-        {
-            $r .= chr(ord($byte) & ~0x80);
-        }
-
-        last if !defined $post;
-        $s = $post;
-    }
-
-    $r .= $s;
-
-    return $r;
-}
-
 # List annotations actually stored in the database.
 sub list_annotations
 {
@@ -170,68 +136,56 @@ sub list_annotations
         die "Unknown scope: $scope";
     }
 
-    my $tmpfile = tmpnam();
     my $format = $instance->{config}->get('annotation_db');
-    $format = $format // 'skiplist';
-
-    $instance->run_command({ cyrus => 1 },
-                        'cvt_cyrusdb',
-                        $mailbox_db, $format,
-                        $tmpfile, 'flat');
+    $format = $format // 'twoskip';
 
     my @annots;
-    open TMP, '<', $tmpfile
-        or die "Cannot open $tmpfile for reading: $!";
-    while (<TMP>)
-    {
-        chomp;
-        my ($key, $value) = split(/\t/, $_, 2);
-        my @f = split(/\0/, unescape($key), 4);
-        $value = unescape($value);
 
-        # Damn stupid database format has sizeof(long) bytes of length.
-        my ($length) = unpack("N", $value);
-
-    # In records written by older versions of Cyrus, there will be
-    # binary encoded content-type and modifiedsince values after the
-    # data. We don't care about those anymore, but need to skip past
-    # them the entry metadata.
-    my @entry = split(/\0/, substr($value, $Config{longsize}), 3);
-    my $annot = {
-            uid => ($scope eq 'message' ? $f[0] : 0),
-            mboxname => ($scope eq 'message' ? $mailbox : $f[0]),
-            entry => $f[1],
-            userid => $f[2],
-            data => $entry[0],
+    my $res = $instance->run_dbcommand_cb(sub {
+        my ($key, $value) = @_;
+        my ($uid, $item, $userid, @rest) = split '\0', $key;
+        my $offset = 0;
+        my $vallen = unpack('N', substr($value, $offset, 4));
+        $offset += 8; # 4 more bytes of rubbish
+        my $val = substr($value, $offset, $vallen);
+        $offset += $vallen + 1; # trailing null
+        my $strend = index($value, "\0", $offset);
+        my $type = substr($value, $offset, ($strend - $offset));
+        $offset = $strend + 1;
+        my $modtime = unpack('N', substr($value, $offset, 4));
+        $offset += 8; # 4 more bytes of rubbish again
+        my $modseq = unpack('x[N]N', substr($value, $offset, 8));
+        $offset += 8;
+        my $flags = unpack('C', substr($value, $offset, 1));
+        if ($flags and not $tombstones) {
+            return;
+        }
+        my $annot = {
+            uid => ($scope eq 'message' ? $uid : 0),
+            mboxname => ($scope eq 'message' ? $mailbox : $uid),
+            entry => $item,
+            userid => $userid,
+            data => $val,
         };
 
-    if ($entry[2]) {
-        my ($modseq, $flags) =
-            unpack("Q>C", bytes::substr($entry[2], $Config{longsize}));
-        if ($flags and not $tombstones) {
-            next;
-        }
         if ($withmdata) {
             $annot->{modseq} = $modseq;
             $annot->{flags} = $flags;
         }
-    }
 
-    if ($uids) {
-        my %wantuids = map { $_ => 1 } $uids;
-        if ($uids and not exists($wantuids{$annot->{uid}})) {
-            next;
+        if ($uids) {
+            my %wantuids = map { $_ => 1 } $uids;
+            if ($uids and not exists($wantuids{$annot->{uid}})) {
+                return;
+            }
         }
-    }
 
         if ($annot->{userid} eq '[.OwNeR.]') {
             $annot->{userid} = 'cassandane'; # XXX - strip owner from $mailbox?
         }
 
         push(@annots, $annot);
-    }
-    close(TMP);
-    unlink($tmpfile);
+    }, $mailbox_db, $format, ['SHOW']);
 
     # enforce a stable order so we have some chance of
     # comparing the results

--- a/Cassandane/Cyrus/Metadata.pm
+++ b/Cassandane/Cyrus/Metadata.pm
@@ -2164,8 +2164,10 @@ sub test_msg_replication_new_mas_partial_wwd
     $self->run_replication();
     $self->check_msg_annotation_replication($master_store, $replica_store);
 
-    xlog $self, "Write another annotation";
+    xlog $self, "Write another few annotations";
     $self->set_msg_annotation($master_store, 1, '/altsubject', 'value.priv', 'a1');
+    $self->set_msg_annotation($master_store, 1, '/comment', 'value.shared', 'cs');
+    $self->set_msg_annotation($master_store, 1, '/altsubject', 'value.shared', 'as');
 
     xlog $self, "Run replication";
     $self->run_replication();
@@ -2173,6 +2175,7 @@ sub test_msg_replication_new_mas_partial_wwd
 
     xlog $self, "Delete the first annotation";
     $self->set_msg_annotation($master_store, 1, '/comment', 'value.priv', '');
+    $self->set_msg_annotation($master_store, 1, '/altsubject', 'value.shared', '');
 
     xlog $self, "Run replication";
     $self->run_replication();

--- a/Cassandane/Cyrus/Rename.pm
+++ b/Cassandane/Cyrus/Rename.pm
@@ -703,7 +703,7 @@ sub _dbset
         'twoskip',
         defined($value)
           ? ['SET', $key => $value]
-          : ['delete', $key],
+          : ['DELETE', $key],
     ));
 }
 

--- a/Cassandane/Cyrus/Rename.pm
+++ b/Cassandane/Cyrus/Rename.pm
@@ -697,15 +697,14 @@ sub _match_intermediates
 sub _dbset
 {
     my ($self, $key, $value) = @_;
-    $self->{instance}->run_command(
-        { cyrus => 1 },
-        'cyr_dbtool',
+    $self->assert_str_eq('ok', $self->{instance}->run_dbcommand_cb(
+        sub { die "got a response!" },
         "$self->{instance}->{basedir}/conf/mailboxes.db",
         'twoskip',
         defined($value)
-          ? ('set', $key => $value)
-          : ('delete', $key),
-    );
+          ? ['SET', $key => $value]
+          : ['delete', $key],
+    ));
 }
 
 sub test_intermediate_cleanup

--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -2394,4 +2394,165 @@ sub run_mbpath
     return decode_json($str);
 }
 
+sub _mkastring
+{
+  my $string = shift;
+  return '{' . length($string) . '+}' . "\r\n" . $string;
+}
+
+sub run_dbcommand_cb
+{
+  my $self = shift;
+  my ($linecb, $dbname, $engine, @items) = @_;
+
+  if (@items > 1) {
+    unshift @items, ['BEGIN'];
+    push @items, ['COMMIT'];
+  }
+
+  my $input = '';
+  foreach my $item (@items) {
+    $input .= $item->[0];
+    for (1..2) {
+      $input .= ' ' . _mkastring($item->[$_]) if defined $item->[$_];
+    }
+    $input .= "\r\n";
+  }
+
+  my $basedir = $self->{basedir};
+  my $res = $self->run_command({
+     redirects => {
+         stdin => \$input,
+         stdout => "$basedir/run_dbcommand.out",
+     },
+     cyrus => 1,
+     handlers => {
+         exited_normally => sub { return 'ok'; },
+         exited_abnormally => sub { return 'failure'; },
+     },
+  }, 'cyr_dbtool', $dbname, $engine, 'batch');
+  return $res unless $res eq 'ok';
+
+  my $needbytes = 0;
+  my $buf = '';
+
+  # The output of `cyr_dbtool` is in theory one logical line at a time.
+  #  However each logical line can have IMAP literals in them. In that
+  #  case, you get a real line that ends with "{nbytes+}\r\n" and you then
+  #  have to read that many bytes of data (including possibly \r's and
+  #  \n's as well). This function potentially reads multiple real lines
+  #  in $line to gather up a single logical line in $buf, and then parses
+  #  that.
+  # It could be made simpler and more efficient by tokenising the line as
+  #  it goes, but it was extracted from an original codebase which processed
+  #  the entire response buffer from `cyr_dbtool` as a single giant string.
+  open(FH, "<$basedir/run_dbcommand.out");
+  LINE: while (defined(my $line = <FH>)) {
+    $buf .= $line;
+
+    # inside a literal, that's all we need
+    if ($needbytes) {
+      my $len = length($line);
+      if ($len <= $needbytes) {
+        $needbytes -= $len;
+        next LINE;
+      }
+      substr($line, 0, $needbytes, '');
+      $needbytes = 0;
+    }
+
+    # does this line include a literal, process it now
+    if ($line =~ m/\{(\d+)\+?\}\r?\n$/s) {
+      $needbytes = $1;
+      next LINE;
+    }
+
+    # we have a line!
+
+    my @array;
+    my $pos = 0;
+    my $length = length($buf);
+    while ($pos < $length) {
+      my $chr = substr($buf, $pos, 1);
+
+      if ($chr eq ' ') {
+        $pos++;
+        next;
+      }
+
+      if ($chr eq "\n") {
+        $pos++;
+        next;
+      }
+
+      if ($chr eq '{') {
+        my $end = index($buf, '}', $pos);
+        die "Missing }" if $end < 0;
+        my $len = substr($buf, $pos + 1, $end - $pos - 2);
+        $len =~ s/\+//;
+        $pos = $end+1;
+        my $chr = substr($buf, $pos++, 1);
+        $chr = substr($buf, $pos++, 1) if $chr eq "\r";
+        die "BOGUS LITERAL" unless $chr eq "\n";
+        push @array, substr($buf, $pos, $len);
+        $pos += $len;
+        next;
+      }
+
+      if ($chr eq '"') {
+        my $end = index($buf, '"', $pos+1);
+        die "Missing quote" if $end < 0;
+        push @array, substr($buf, $pos + 1, $end - $pos - 1);
+        $pos = $end + 1;
+        next;
+      }
+
+      my $space = index($buf, ' ', $pos);
+      my $endline = index($buf, "\n", $pos);
+
+      if ($space < 0) {
+        push @array, substr($buf, $pos, $endline - $pos);
+        $pos = $endline;
+        next;
+      }
+
+      if ($endline < 0) {
+        push @array, substr($buf, $pos, $space - $pos);
+        $pos = $space;
+        next;
+      }
+
+      if ($endline < $space) {
+        push @array, substr($buf, $pos, $endline - $pos);
+        $pos = $endline;
+        next;
+      }
+
+      if ($space < $endline) {
+        push @array, substr($buf, $pos, $space - $pos);
+        $pos = $space;
+        next;
+      }
+
+      die "shouldn't get here";
+    }
+
+    $linecb->(@array);
+
+    $buf = '';
+  }
+  close(FH);
+
+  return 'ok';
+}
+
+sub run_dbcommand
+{
+  my $self = shift;
+  my ($dbname, $engine, @items) = @_;
+  my @array;
+  $self->run_dbcommand_cb(sub { push @array, @_ }, $dbname, $engine, @items);
+  return @array;
+}
+
 1;


### PR DESCRIPTION
This was SUPPOSED to be a small metadata test, and turned into realising that all of the Metadata tests weren't actually working correctly, because list_annotations wasn't doing what it said on the tin for two separate bugs - but comparing the replication still got us zero / zero annotations, which funnily enough passed the tests.

Doing things this way gives us a much more powerful ability to manipulate database files.