### PR TITLE
Add support for testing JMAP in a murder setup

### DIFF
--- a/Cassandane/Cyrus/JMAPCore.pm
+++ b/Cassandane/Cyrus/JMAPCore.pm
@@ -555,7 +555,7 @@ sub test_require_conversations
     $instance->{config}->set(conversations => 'no');
 
     $self->_start_instances();
-    $self->_jmap_setup();
+    $self->_setup_http_service_objects();
 
     my $jmap = $self->{jmap};
     my $JMAPRequest = {

--- a/Cassandane/Cyrus/Murder.pm
+++ b/Cassandane/Cyrus/Murder.pm
@@ -52,7 +52,7 @@ $Data::Dumper::Sortkeys = 1;
 sub new
 {
     my $class = shift;
-    return $class->SUPER::new({ murder => 1, adminstore => 1 }, @_);
+    return $class->SUPER::new({ imapmurder => 1, adminstore => 1 }, @_);
 }
 
 sub set_up

--- a/Cassandane/Cyrus/MurderIMAP.pm
+++ b/Cassandane/Cyrus/MurderIMAP.pm
@@ -37,7 +37,7 @@
 #  OF THIS SOFTWARE.
 #
 
-package Cassandane::Cyrus::Murder;
+package Cassandane::Cyrus::MurderIMAP;
 use strict;
 use warnings;
 use Data::Dumper;

--- a/Cassandane/Cyrus/MurderJMAP.pm
+++ b/Cassandane/Cyrus/MurderJMAP.pm
@@ -181,4 +181,35 @@ sub test_backend1_commands
     # XXX test other commands
 }
 
+sub test_backend2_commands
+    :needs_component_jmap :min_version_3_5
+{
+    my ($self) = @_;
+    my $result;
+
+    my $backend2_svc = $self->{backend2}->get_service("http");
+    my $backend2_host = $backend2_svc->host();
+    my $backend2_port = $backend2_svc->port();
+
+    my $backend2_jmap = Mail::JMAPTalk->new(
+        user => 'cassandane',
+        password => 'pass',
+        host => $backend2_host,
+        port => $backend2_port,
+        scheme => 'http',
+        url => '/jmap/',
+    );
+
+    # try to upload a blob
+    my ($resp, $data) = $backend2_jmap->Upload("some test", "text/plain");
+
+    # user doesn't exist on this backend, so upload url should not exist
+    $self->assert_num_equals(404, $resp->{status});
+    $self->assert_str_equals('Not Found', $resp->{reason});
+
+    $self->assert_null($data);
+
+#    # XXX test other commands
+}
+
 1;

--- a/Cassandane/Cyrus/MurderJMAP.pm
+++ b/Cassandane/Cyrus/MurderJMAP.pm
@@ -1,0 +1,100 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2017 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::MurderJMAP;
+use strict;
+use warnings;
+use Data::Dumper;
+
+use lib '.';
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+use Cassandane::Instance;
+
+$Data::Dumper::Sortkeys = 1;
+
+sub new
+{
+    my ($class, @args) = @_;
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set('conversations' => 'yes');
+    $config->set_bits('httpmodules', 'jmap');
+
+    return $class->SUPER::new({
+        config => $config,
+        httpmurder => 1,
+        jmap => 1,
+        adminstore => 1
+    }, @args);
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+sub test_aaa_setup
+{
+    my ($self) = @_;
+
+    # does everything set up and tear down cleanly?
+    $self->assert(1);
+}
+
+# XXX This can't pass because we don't support multiple murder services
+# XXX at once, but renaming out the "bogus" and running it, and it failing,
+# XXX proves the infrastructure to prevent requesting both works.
+sub bogustest_aaa_imapjmap_setup
+    :IMAPMurder
+{
+    my ($self) = @_;
+
+    # does everything set up and tear down cleanly?
+    $self->assert(1);
+}
+
+1;

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -87,7 +87,8 @@ sub new
     my $want = {
         instance => 1,
         replica => 0,
-        murder => 0,
+        imapmurder => 0,
+        httpmurder => 0,
         backups => 0,
         start_instances => 1,
         services => [ 'imap' ],
@@ -201,7 +202,8 @@ magic(CSyncReplication => sub {
     $self->want('csyncreplica');
     $self->config_set('sync_try_imap' => 0);
 });
-magic(Murder => sub { shift->want('murder'); });
+magic(IMAPMurder => sub { shift->want('imapmurder'); });
+magic(HTTPMurder => sub { shift->want('httpmurder'); });
 magic(Backups => sub { shift->want('backups'); });
 magic(AnnotationAllowUndefined => sub {
     shift->config_set(annotation_allow_undefined => 1);
@@ -411,9 +413,9 @@ sub _create_instances
     my ($self) = @_;
     my $sync_port;
     my $mupdate_port;
-    my $frontend_imapd_port;
-    my $backend1_imapd_port;
-    my $backend2_imapd_port;
+    my $frontend_service_port;
+    my $backend1_service_port;
+    my $backend2_service_port;
     my $backupd_port;
 
     $self->{_config} = $self->{_instance_params}->{config} || Cassandane::Config->default();
@@ -425,6 +427,16 @@ sub _create_instances
     my %instance_params = %{$self->{_instance_params}};
 
     my $cassini = Cassandane::Cassini->instance();
+
+    if ($want->{imapmurder} && $want->{httpmurder}) {
+        # XXX Murder is implemented assuming that everything is on standard
+        # XXX ports, but Cassandane needs to use high port numbers.
+        # XXX We fudge a workaround here by embedding the service port
+        # XXX number in the server name, which tricks Murder into using
+        # XXX that port number instead of the standard one, but that means
+        # XXX we can only have one proxied service per instance.
+        die "Cannot enable murder for both IMAP and JMAP at the same time";
+    }
 
     if ($want->{instance})
     {
@@ -443,13 +455,13 @@ sub _create_instances
             );
         }
 
-        if ($want->{murder})
+        if ($want->{imapmurder} || $want->{httpmurder})
         {
             $mupdate_port = Cassandane::PortManager::alloc();
-            $backend1_imapd_port = Cassandane::PortManager::alloc();
+            $backend1_service_port = Cassandane::PortManager::alloc();
 
             $conf->set(
-                servername => "localhost:$backend1_imapd_port",
+                servername => "localhost:$backend1_service_port",
                 mupdate_server => "localhost:$mupdate_port",
                 # XXX documentation says to use mupdate_port, but
                 # XXX this doesn't work -- need to embed port number in
@@ -521,15 +533,15 @@ sub _create_instances
                 if ($want->{deliver});
         }
 
-        if ($want->{murder})
+        if ($want->{imapmurder} || $want->{httpmurder})
         {
-            $frontend_imapd_port = Cassandane::PortManager::alloc();
-            $backend2_imapd_port = Cassandane::PortManager::alloc();
+            $frontend_service_port = Cassandane::PortManager::alloc();
+            $backend2_service_port = Cassandane::PortManager::alloc();
 
             # set up a front end on which we also run the mupdate master
             my $frontend_conf = $self->{_config}->clone();
             $frontend_conf->set(
-                servername => "localhost:$frontend_imapd_port",
+                servername => "localhost:$frontend_service_port",
                 mupdate_server => "localhost:$mupdate_port",
                 # XXX documentation says to use mupdate_port, but
                 # XXX this doesn't work -- need to embed port number in
@@ -539,7 +551,7 @@ sub _create_instances
                 mupdate_authname => 'mupduser',
                 mupdate_password => 'mupdpass',
                 serverlist =>
-                    "localhost:$backend1_imapd_port localhost:$backend2_imapd_port",
+                    "localhost:$backend1_service_port localhost:$backend2_service_port",
                 proxy_authname => 'mailproxy',
                 proxy_password => 'mailproxy',
             );
@@ -562,25 +574,44 @@ sub _create_instances
             $self->{frontend}->_setup_for_deliver()
                 if ($want->{deliver});
 
-            # arrange for frontend imapd to run on a known port
-            $self->{frontend}->remove_service('imap');
-            $self->{frontend}->add_service(name => 'imap',
-                                           port => $frontend_imapd_port);
+            # arrange for frontend service to run on a known port
+            if ($want->{imapmurder}) {
+                $self->{frontend}->remove_service('imap');
+                $self->{frontend}->add_service(name => 'imap',
+                                               port => $frontend_service_port);
+            }
+            elsif ($want->{httpmurder}) {
+                $self->{frontend}->remove_service('http');
+                $self->{frontend}->add_service(name => 'http',
+                                               port => $frontend_service_port);
+            }
+            else {
+                die "shouldn't get here!";
+            }
 
             # arrange for backend1 to push to mupdate on startup
             $self->{instance}->add_start(name => 'mupdatepush',
                                          argv => ['ctl_mboxlist', '-m']);
 
-            # arrange for backend1 imapd to run on a known port
-            $self->{instance}->remove_service('imap');
-            $self->{instance}->add_service(name => 'imap',
-                                           port => $backend1_imapd_port);
-
+            # arrange for backend1 service to run on a known port
+            if ($want->{imapmurder}) {
+                $self->{instance}->remove_service('imap');
+                $self->{instance}->add_service(name => 'imap',
+                                               port => $backend1_service_port);
+            }
+            elsif ($want->{httpmurder}) {
+                $self->{instance}->remove_service('http');
+                $self->{instance}->add_service(name => 'http',
+                                               port => $backend1_service_port);
+            }
+            else {
+                die "shouldn't get here!";
+            }
 
             # set up a second backend
             my $backend2_conf = $self->{_config}->clone();
             $backend2_conf->set(
-                servername => "localhost:$backend2_imapd_port",
+                servername => "localhost:$backend2_service_port",
                 mupdate_server => "localhost:$mupdate_port",
                 # XXX documentation says to use mupdate_port, but
                 # XXX this doesn't work -- need to embed port number in
@@ -606,10 +637,20 @@ sub _create_instances
             $self->{backend2}->add_start(name => 'mupdatepush',
                                          argv => ['ctl_mboxlist', '-m']);
 
-            # arrange for backend2 imap to run on a known port
-            $self->{backend2}->remove_service('imap');
-            $self->{backend2}->add_service(name => 'imap',
-                                           port => $backend2_imapd_port);
+            # arrange for backend2 service to run on a known port
+            if ($want->{imapmurder}) {
+                $self->{backend2}->remove_service('imap');
+                $self->{backend2}->add_service(name => 'imap',
+                                               port => $backend2_service_port);
+            }
+            elsif ($want->{httpmurder}) {
+                $self->{backend2}->remove_service('http');
+                $self->{backend2}->add_service(name => 'http',
+                                               port => $backend2_service_port);
+            }
+            else {
+                die "shouldn't get here!";
+            }
 
             $self->{backend2}->_setup_for_deliver()
                 if ($want->{deliver});

--- a/Cassandane/Cyrus/TesterCalDAV.pm
+++ b/Cassandane/Cyrus/TesterCalDAV.pm
@@ -1480,7 +1480,7 @@ sub new
 
     my $buildinfo = Cassandane::BuildInfo->new();
 
-    if (not $buildinfo->get('component', 'httpd')) {
+    if (not defined $basedir or not $buildinfo->get('component', 'httpd')) {
         # don't bother setting up, we're not running tests anyway
         return $class->SUPER::new({}, @_);
     }
@@ -1503,7 +1503,9 @@ sub set_up
     my ($self) = @_;
     $self->SUPER::set_up();
 
-    if (not $self->{instance}->{buildinfo}->get('component', 'httpd')) {
+    if (not defined $basedir
+        or not $self->{instance}->{buildinfo}->get('component', 'httpd'))
+    {
         # don't bother setting up further, we're not running tests anyway
         return;
     }

--- a/Cassandane/Cyrus/TesterCardDAV.pm
+++ b/Cassandane/Cyrus/TesterCardDAV.pm
@@ -171,7 +171,7 @@ sub new
 
     my $buildinfo = Cassandane::BuildInfo->new();
 
-    if (not $buildinfo->get('component', 'httpd')) {
+    if (not defined $basedir or not $buildinfo->get('component', 'httpd')) {
         # don't bother setting up, we're not running tests anyway
         return $class->SUPER::new({}, @_);
     }
@@ -194,7 +194,9 @@ sub set_up
     my ($self) = @_;
     $self->SUPER::set_up();
 
-    if (not $self->{instance}->{buildinfo}->get('component', 'httpd')) {
+    if (not defined $basedir
+        or not $self->{instance}->{buildinfo}->get('component', 'httpd'))
+    {
         # don't bother setting up further, we're not running tests anyway
         return;
     }


### PR DESCRIPTION
This is for https://github.com/cyrusimap/cyrus-imapd/pull/3564

We have a small handful of very basic tests for murder setups (Murder.pm), but the way we set things up in Cassandane meant these could only use IMAP.

This PR adjusts the infrastructure so that a test can _either_ require an IMAP murder or a JMAP murder (but not both!), modifies the existing Murder.pm tests to use the new infrastructure, and adds a couple of basic JMAP tests too.

We can and should add more tests to this, but so far this proves that the basic premise -- connecting to the frontend, making a JMAP request, and the request being proxied to the backend containing the user's account -- seems to work.

There's probably more to do with the infrastructure yet, but I won't be sure what it needs to look like until we write and debug more tests.