### PR TITLE
fixes for problems found while testing 3.4

### DIFF
--- a/Cassandane/Cyrus/Replication.pm
+++ b/Cassandane/Cyrus/Replication.pm
@@ -2084,6 +2084,7 @@ sub test_splitbrain_different_uniqueid_unused
 # Test non-empty mailbox causes replication to abort
 #
 sub test_splitbrain_different_uniqueid_nonempty
+    :min_version_3_5
 {
     my ($self) = @_;
 
@@ -2137,6 +2138,7 @@ sub test_splitbrain_different_uniqueid_nonempty
 # Test mailbox that's had email but is now empty again
 #
 sub test_splitbrain_different_uniqueid_used
+    :min_version_3_5
 {
     my ($self) = @_;
 

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -835,36 +835,41 @@ sub tear_down
     $self->{backend1_store} = undef;
     $self->{backend1_adminstore} = undef;
 
+    my $sanity_errors = 0;
+
     if (defined $self->{instance})
     {
-        $self->{instance}->stop();
+        $sanity_errors += $self->{instance}->stop();
         $self->{instance}->cleanup();
         $self->{instance} = undef;
     }
     if (defined $self->{backups})
     {
-        $self->{backups}->stop();
+        $sanity_errors += $self->{backups}->stop();
         $self->{backups}->cleanup();
         $self->{backups} = undef;
     }
     if (defined $self->{backend2})
     {
-        $self->{backend2}->stop();
+        $sanity_errors += $self->{backend2}->stop();
         $self->{backend2}->cleanup();
         $self->{backend2} = undef;
     }
     if (defined $self->{replica})
     {
-        $self->{replica}->stop();
+        $sanity_errors += $self->{replica}->stop();
         $self->{replica}->cleanup();
         $self->{replica} = undef;
     }
     if (defined $self->{frontend})
     {
-        $self->{frontend}->stop();
+        $sanity_errors += $self->{frontend}->stop();
         $self->{frontend}->cleanup();
         $self->{frontend} = undef;
     }
+
+    die "INCONSISTENCIES FOUND IN SPOOL" if $sanity_errors;
+
     xlog "---------- END $self->{_name} ----------";
 }
 

--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -2316,7 +2316,7 @@ sub get_servername
 sub run_mbpath
 {
     my ($self, @args) = @_;
-    my ($maj, $min) = Cassandane::Instance->get_version();
+    my ($maj, $min) = Cassandane::Instance->get_version($self->{installation});
     my $basedir = $self->get_basedir();
     if ($maj < 3 || $maj == 3 && $min <= 4) {
         my $folder = pop @args;

--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -1337,6 +1337,15 @@ sub _check_cores
 sub _check_sanity
 {
     my ($self) = @_;
+
+    # We added this check during 3.5 development... older versions
+    # probably fail these checks.  If we backport fixes we can decrement
+    # this version check.
+    my ($maj, $min) = Cassandane::Instance->get_version($self->{installation});
+    if ($maj < 3 || ($maj == 3 && $min < 5)) {
+        return 0;
+    }
+
     my $basedir = $self->{basedir};
     my $found = 0;
     eval {

--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -1469,7 +1469,9 @@ sub stop
     $self->_check_cores();
     $self->_check_syslog();
 
-    die "INCONSISTENCIES FOUND IN SPOOL" if $sanity_errors;
+    xlog "$self->{description}: INCONSISTENCIES FOUND IN SPOOL"
+        if $sanity_errors;
+    return $sanity_errors;
 }
 
 sub cleanup


### PR DESCRIPTION
* clean up properly after Instance::_check_sanity() finds errors (prevents later tests from failing due to port conflicts)
* _check_sanity() does nothing if the instance's Cyrus is older than 3.5
* fixed the version check in run_mbpath() to check the correct Cyrus
* fixed some missing :min_version_3_5's