### PR TITLE
re-add DEBUGJMAP (removed in cf7d0c6c11ec3b5e437697a74249395a2cfff8a0)

### DIFF
--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -726,6 +726,7 @@ sub _setup_http_service_objects
         }
         if ($self->{instance}->{config}->get_bit('httpmodules', 'jmap')) {
             require Mail::JMAPTalk;
+            $ENV{DEBUGJMAP} = 1;
             $self->{jmap} = Mail::JMAPTalk->new(
                 user => 'cassandane',
                 password => 'pass',


### PR DESCRIPTION
This allows run with `-v -v` to spit out JMAP traffic.