### PR TITLE
Tests for XFER of user and mailbox

### DIFF
--- a/Cassandane/Cyrus/MurderIMAP.pm
+++ b/Cassandane/Cyrus/MurderIMAP.pm
@@ -371,4 +371,41 @@ sub test_rename_with_location
     $self->assert_str_equals('ok', $backend2_store->get_last_completion_response());
 }
 
+sub test_xfer_nonexistent_unixhs
+    :UnixHierarchySep
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{backend1_adminstore}->get_client();
+    my $backend2_servername = $self->{backend2}->get_servername();
+
+    # xfer a user that doesn't exist
+    $admintalk->_imap_cmd('xfer', 0, {},
+                          'user/nonexistent', $backend2_servername);
+    $self->assert_str_equals(
+        'no', $admintalk->get_last_completion_response()
+    );
+
+    # xfer a mailbox that doesn't exist
+    $admintalk->_imap_cmd('xfer', 0, {},
+                          'user/cassandane/nonexistent', $backend2_servername);
+    $self->assert_str_equals(
+        'no', $admintalk->get_last_completion_response()
+    );
+
+    # xfer a pattern that doesn't match anything
+    $admintalk->_imap_cmd('xfer', 0, {},
+                          'user/cassandane/non%', $backend2_servername);
+    $self->assert_str_equals(
+        'no', $admintalk->get_last_completion_response()
+    );
+
+    # xfer a partition that doesn't exist
+    $admintalk->_imap_cmd('xfer', 0, {},
+                          'nonexistent', $backend2_servername);
+    $self->assert_str_equals(
+        'no', $admintalk->get_last_completion_response()
+    );
+}
+
 1;

--- a/Cassandane/Cyrus/Pop3.pm
+++ b/Cassandane/Cyrus/Pop3.pm
@@ -153,6 +153,8 @@ sub test_subfolder_login
 
     $imapclient->create('INBOX.sub');
     $self->{store}->set_folder('INBOX.sub');
+    # different mailbox, so reset generator's expected uid sequence
+    $self->{gen}->set_next_uid(1);
 
     my %subexp;
     $subexp{B} = $self->make_message('Message B');
@@ -182,10 +184,8 @@ sub test_subfolder_login
     $self->assert_equals($subclient->code(), 200);
     my $sublines = $subclient->read_until_dot();
     my %subactual;
-    # note: "uid 2" is totally bogus here, because the "generator" doesn't
-    # notice the folder change and hence the new UID space...
     $subactual{'Message B'} = Cassandane::Message->new(lines => $sublines,
-                                                       attrs => { uid => 2 });
+                                                       attrs => { uid => 1 });
     $self->check_messages(\%subexp, actual => \%subactual);
 }
 

--- a/Cassandane/IMAPMessageStore.pm
+++ b/Cassandane/IMAPMessageStore.pm
@@ -198,6 +198,13 @@ sub write_message
     $self->{client}->append($self->{folder}, @extra,
                             { Literal => $msg->as_string() } )
                             || die "$@";
+
+    # if we know the uid and uidvalidity, update the msg object
+    my $appenduid = $self->{client}->get_response_code('appenduid');
+    if (defined $appenduid and ref $appenduid eq 'ARRAY') {
+        $msg->set_attribute(uidvalidity => $appenduid->[0]);
+        $msg->set_attribute(uid => $appenduid->[1]);
+    }
 }
 
 sub write_end


### PR DESCRIPTION
This adds a bunch of tests for XFER of a user, and one test for XFER of a single mailbox.  These tests are for the fixes in https://github.com/cyrusimap/cyrus-imapd/pull/3693

The XFER user tests are fairly exhaustive, because that was my focus.  They are all `:min_version_3_2` because an unrelated behaviour changed in 3.2 (implied `RETURN (SPECIAL-USE)` in LIST), and so as written the tests don't pass on 3.0.  They can be tinkered with to prove the fixes work for 3.0 as well, but I didn't feel like duplicating them just for that.

The XFER mailbox test is singular for now, just to make sure nothing unexpected broke.  It is `:max_version_3_4` because it turns out 3.5 can create an intermediate on this code path, which is bad!  That'll need fixing separately, so it'll get a test case separately too.

Also adds a convenience detail to IMAPMessageStore (if we know the real uid and uidvalidity when appending a message, update the local copy to match), and fixes a test in Pop3 that had a bogus assumption that the improved IMAPMessageStore exposed.

This does not yet add any tests for XFER where the name is a mailbox pattern, nor a partition name.  I don't expect those cases to be affected by the bugs I've been addressing so far, so I'll write those tests later, when I'm working on those things.