### PR TITLE
Look for cassandane.ini in more places, give up if it's missing

### DIFF
--- a/Cassandane/Cassini.pm
+++ b/Cassandane/Cassini.pm
@@ -90,6 +90,8 @@ sub new
             }
         }
     }
+
+    die "couldn't find a cassandane.ini file" if not $filename;
     $filename = abs_path($filename);
 
     my $inifile = new Config::IniFiles();

--- a/Cassandane/Cassini.pm
+++ b/Cassandane/Cassini.pm
@@ -50,13 +50,46 @@ use Cassandane::Util::Log;
 
 my $instance;
 
+sub homedir {
+    my ($uid) = @_;
+
+    my @pw = getpwuid($uid);
+    return $pw[7]; # dir field
+}
+
 sub new
 {
     my ($class, %params) = @_;
 
-    my $filename = 'cassandane.ini';
-    $filename = $params{filename}
-        if defined $params{filename};
+    my $filename;
+
+    if (defined $params{filename}) {
+        # explicitly requested filename: just use it
+        $filename = $params{filename};
+    }
+    else {
+        # check some likely places, in order
+        foreach my $dir (q{.},
+                         q{..},
+                         homedir($>),
+                         homedir($<),
+                         homedir($ENV{SUDO_UID})
+        ) {
+            next if not $dir;
+
+            # might be called "cassandane.ini"
+            if (-e "$dir/cassandane.ini") {
+                $filename = "$dir/cassandane.ini";
+                last;
+            }
+
+            # might be called ".cassandane.ini"
+            if (-e "$dir/.cassandane.ini") {
+                $filename = "$dir/.cassandane.ini";
+                last;
+            }
+        }
+    }
     $filename = abs_path($filename);
 
     my $inifile = new Config::IniFiles();

--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -1827,7 +1827,7 @@ sub _fork_command
         or die "Cannot cd to $cd: $!";
 
     # ulimit -c ...
-    my $cassini = Cassandane::Cassini::instance();
+    my $cassini = Cassandane::Cassini->instance();
     my $coresizelimit = 0 + $cassini->val("cyrus $self->{installation}",
                                           'coresizelimit', '100');
     if ($coresizelimit <= 0) {

--- a/Cassandane/Unit/Runner.pm
+++ b/Cassandane/Unit/Runner.pm
@@ -53,7 +53,7 @@ sub new
     my $self = $class->SUPER::new(@_);
     $self->{remove_me_in_cassandane_child} = 1;
 
-    my $cassini = Cassandane::Cassini::instance();
+    my $cassini = Cassandane::Cassini->instance();
     my $rootdir = $cassini->val('cassandane', 'rootdir', '/var/tmp/cass');
     my $failed_file = "$rootdir/failed";
     $self->{failed_fh} = IO::File->new($failed_file, 'w');

--- a/Cassandane/Unit/RunnerPretty.pm
+++ b/Cassandane/Unit/RunnerPretty.pm
@@ -53,7 +53,7 @@ sub new
         # reports to $rootdir/reports (if we can) rather than terminal
         $self->{_quiet} = 1;
 
-        my $cassini = Cassandane::Cassini::instance();
+        my $cassini = Cassandane::Cassini->instance();
         my $rootdir = $cassini->val('cassandane', 'rootdir', '/var/tmp/cass');
         my $quiet_report_file = "$rootdir/reports";
 

--- a/Cassandane/Unit/TestPlan.pm
+++ b/Cassandane/Unit/TestPlan.pm
@@ -581,7 +581,7 @@ sub _default_test_list
 {
     my ($self) = @_;
 
-    my $cassini = Cassandane::Cassini::instance();
+    my $cassini = Cassandane::Cassini->instance();
     my @tosuppress = split /\s+/, $cassini->val('cassandane', 'suppress', '');
 
     my %default;

--- a/testrunner.pl
+++ b/testrunner.pl
@@ -278,7 +278,7 @@ while (my $a = shift)
     }
     elsif ($a eq '--rerun')
     {
-        my $cassini = Cassandane::Cassini::instance();
+        my $cassini = Cassandane::Cassini->instance();
         my $rootdir = $cassini->val('cassandane', 'rootdir', '/var/tmp/cass');
         my $failed_file = "$rootdir/failed";
 


### PR DESCRIPTION
This will become more important once cassandane is merged into the cyrus repo.

The main practical outcome here is that you can keep your cassandane.ini in your home directory, rather than in the repo (where's it's vulnerable to being wiped by a `git clean`), though you can still keep it in the repo if you want.  You can now also call it ".cassandane.ini" if you like.  

It's a little more complicated than you'd think it needs to be because `become_cyrus()` usually re-execs the script with `sudo -u cyrus`, and sudo sets _both_ the real and effective uids, so you also need to check $SUDO_UID to find out who the process really belongs to.  I didn't want to have to put my cassandane.ini in cyrus's home directory (cause that's annoying to edit), nor assume the cyrus user even has a home directory, but if it does and there's a cassandane.ini file there it will use it.  If not, it will look in your home directory next.

I've also never seen Cassandane successfully run without a cassandane.ini file, so I made it just die with an error if it's missing, instead of naively trying to run with pure defaults and every test failing.

Also fixed a little quirk with how the --rerun and --config options are handled, and fixed a bunch of places where the `Cassandane::Cassini->instance()` class method was being invoked incorrectly (albeit with no ill effect)