### PR TITLE
Cassini: hush warning from homedir() when $uid not defined

### DIFF
--- a/Cassandane/Cassini.pm
+++ b/Cassandane/Cassini.pm
@@ -53,6 +53,8 @@ my $instance;
 sub homedir {
     my ($uid) = @_;
 
+    return undef if not $uid;
+
     my @pw = getpwuid($uid);
     return $pw[7]; # dir field
 }


### PR DESCRIPTION
This happens for example if $ENV{SUDO_UID} isn't defined.
We were just gonna return undef and skip it anyway, so do so
without producing a warning.