### PR TITLE
Better cleanup after errors during instance shutdown

### DIFF
--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -884,40 +884,41 @@ sub tear_down
     $self->{backend1_store} = undef;
     $self->{backend1_adminstore} = undef;
 
-    my $sanity_errors = 0;
+    my @stop_errors;
 
     if (defined $self->{instance})
     {
-        $sanity_errors += $self->{instance}->stop();
+        push @stop_errors, $self->{instance}->stop();
         $self->{instance}->cleanup();
         $self->{instance} = undef;
     }
     if (defined $self->{backups})
     {
-        $sanity_errors += $self->{backups}->stop();
+        push @stop_errors, $self->{backups}->stop();
         $self->{backups}->cleanup();
         $self->{backups} = undef;
     }
     if (defined $self->{backend2})
     {
-        $sanity_errors += $self->{backend2}->stop();
+        push @stop_errors, $self->{backend2}->stop();
         $self->{backend2}->cleanup();
         $self->{backend2} = undef;
     }
     if (defined $self->{replica})
     {
-        $sanity_errors += $self->{replica}->stop();
+        push @stop_errors, $self->{replica}->stop();
         $self->{replica}->cleanup();
         $self->{replica} = undef;
     }
     if (defined $self->{frontend})
     {
-        $sanity_errors += $self->{frontend}->stop();
+        push @stop_errors, $self->{frontend}->stop();
         $self->{frontend}->cleanup();
         $self->{frontend} = undef;
     }
 
-    die "INCONSISTENCIES FOUND IN SPOOL" if $sanity_errors;
+    # maybe there's multiple errors, but we can only die for one of them...
+    die $stop_errors[0] if scalar @stop_errors;
 
     xlog "---------- END $self->{_name} ----------";
 }

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -888,31 +888,31 @@ sub tear_down
 
     if (defined $self->{instance})
     {
-        push @stop_errors, $self->{instance}->stop();
+        eval { push @stop_errors, $self->{instance}->stop() };
         $self->{instance}->cleanup();
         $self->{instance} = undef;
     }
     if (defined $self->{backups})
     {
-        push @stop_errors, $self->{backups}->stop();
+        eval { push @stop_errors, $self->{backups}->stop() };
         $self->{backups}->cleanup();
         $self->{backups} = undef;
     }
     if (defined $self->{backend2})
     {
-        push @stop_errors, $self->{backend2}->stop();
+        eval { push @stop_errors, $self->{backend2}->stop() };
         $self->{backend2}->cleanup();
         $self->{backend2} = undef;
     }
     if (defined $self->{replica})
     {
-        push @stop_errors, $self->{replica}->stop();
+        eval { push @stop_errors, $self->{replica}->stop() };
         $self->{replica}->cleanup();
         $self->{replica} = undef;
     }
     if (defined $self->{frontend})
     {
-        push @stop_errors, $self->{frontend}->stop();
+        eval { push @stop_errors, $self->{frontend}->stop() };
         $self->{frontend}->cleanup();
         $self->{frontend} = undef;
     }

--- a/Cassandane/Test/Core.pm
+++ b/Cassandane/Test/Core.pm
@@ -91,8 +91,8 @@ sub _test_core_files_with_size
     $self->assert_equals(1, $signaled);
     $self->assert_not_null($pid);
 
-    eval { $instance->_check_cores() };
-    my $err = $@;
+    my $err;
+    eval { $err = $instance->_check_cores() };
     $self->assert_matches(qr/Core files found/, $err);
 
     my $core = "$instance->{basedir}/conf/cores/core.$pid";


### PR DESCRIPTION
We keep having problems where errors detected during `Cassandane::Instance::stop()` lead to the test not being cleaned up properly, which then causes cascading failures later due to cassandane's 91xx ports still being in use by processes left behind by earlier tests.

This fixes the problem by carefully removing all the cases where `stop()` could die, and instead collecting those errors into an array that's returned to the caller.

If one of the instances' `stop()`s manages to die somehow anyway, `Cassandane::Cyrus::TestCase::tear_down()` evals and ignores it, and continues cleaning up anyway.  The first error that was returned by `stop()` is used for the eventual die message.

I have tested this for the specific case of "Errors found in syslog", by temporarily building a cyrus where imapd syslogs a fake IOERROR during `shut_down()`.  And indeed, even though nearly every test errors in such a case, cassandane still runs to completion and properly cleans up after every test.

I have _not_ tested this for the other types of errors `stop()` can fail on, for lack of any immediate insight about how to force them to occur (am open to ideas!), so please review carefully.