### PR TITLE
WIP: add a sieve script to XFER tests

### DIFF
--- a/Cassandane/Cyrus/MurderIMAP.pm
+++ b/Cassandane/Cyrus/MurderIMAP.pm
@@ -73,7 +73,7 @@ sub tear_down
 # returning a hash of what to expect to find there later
 sub populate_user
 {
-    my ($self, $store, $folders) = @_;
+    my ($self, $instance, $store, $folders) = @_;
 
     my $messages = {};
 
@@ -142,7 +142,7 @@ sub populate_user
 # populate_user()
 sub check_user
 {
-    my ($self, $store, $expected) = @_;
+    my ($self, $instance, $store, $expected) = @_;
 
     die "bad expected hash" if ref $expected ne 'HASH';
 
@@ -516,7 +516,8 @@ sub test_xfer_user_altns_unixhs
     my ($self) = @_;
 
     # set up some data for cassandane on backend1
-    my $expected = $self->populate_user($self->{backend1_store},
+    my $expected = $self->populate_user($self->{instance},
+                                        $self->{backend1_store},
                                         [qw(INBOX Drafts)]);
 
     my $imaptalk = $self->{backend1_store}->get_client();
@@ -562,7 +563,7 @@ sub test_xfer_user_altns_unixhs
     );
 
     # account contents should be on the other store now
-    $self->check_user($self->{backend2_store}, $expected);
+    $self->check_user($self->{backend2}, $self->{backend2_store}, $expected);
 
     # frontend should now say the user is on the other store
     # XXX is there a better way to discover this?
@@ -618,7 +619,8 @@ sub test_xfer_user_noaltns_nounixhs
     my ($self) = @_;
 
     # set up some data for cassandane on backend1
-    my $expected = $self->populate_user($self->{backend1_store},
+    my $expected = $self->populate_user($self->{instance},
+                                        $self->{backend1_store},
                                         [qw(INBOX INBOX.Drafts)]);
 
     my $imaptalk = $self->{backend1_store}->get_client();
@@ -664,7 +666,7 @@ sub test_xfer_user_noaltns_nounixhs
     );
 
     # account contents should be on the other store now
-    $self->check_user($self->{backend2_store}, $expected);
+    $self->check_user($self->{backend2}, $self->{backend2_store}, $expected);
 
     # frontend should now say the user is on the other store
     # XXX is there a better way to discover this?
@@ -733,7 +735,9 @@ sub test_xfer_user_altns_unixhs_virtdom
         username => 'foo@example.com');
 
     # set up some data for cassandane on backend1
-    my $expected = $self->populate_user($backend1_store, [qw(INBOX Drafts)]);
+    my $expected = $self->populate_user($self->{instance},
+                                        $backend1_store,
+                                        [qw(INBOX Drafts)]);
 
     my $imaptalk = $backend1_store->get_client();
     my $backend2_servername = $self->{backend2}->get_servername();
@@ -778,7 +782,7 @@ sub test_xfer_user_altns_unixhs_virtdom
     );
 
     # account contents should be on the other store now
-    $self->check_user($backend2_store, $expected);
+    $self->check_user($self->{backend2}, $backend2_store, $expected);
 
     # frontend should now say the user is on the other store
     # XXX is there a better way to discover this?
@@ -847,7 +851,8 @@ sub test_xfer_user_noaltns_nounixhs_virtdom
         username => 'foo@example.com');
 
     # set up some data for cassandane on backend1
-    my $expected = $self->populate_user($backend1_store,
+    my $expected = $self->populate_user($self->{instance},
+                                        $backend1_store,
                                         [qw(INBOX INBOX.Drafts)]);
 
     my $imaptalk = $backend1_store->get_client();
@@ -893,7 +898,7 @@ sub test_xfer_user_noaltns_nounixhs_virtdom
     );
 
     # account contents should be on the other store now
-    $self->check_user($backend2_store, $expected);
+    $self->check_user($self->{backend2}, $backend2_store, $expected);
 
     # frontend should now say the user is on the other store
     # XXX is there a better way to discover this?
@@ -958,6 +963,7 @@ sub test_xfer_mailbox_altns_unixhs
 
     # set up some data for cassandane on backend1
     my $expected_stay = $self->populate_user(
+        $self->{instance},
         $self->{backend1_store},
         [qw(INBOX Big Big/Red Big/Red/Dog)]
     );
@@ -1013,9 +1019,13 @@ sub test_xfer_mailbox_altns_unixhs
     );
 
     # most of the account should have remained on the original backend
-    $self->check_user($self->{backend1_store}, $expected_stay);
+    $self->check_user($self->{instance},
+                      $self->{backend1_store},
+                      $expected_stay);
     # but Big/Red should have been moved
-    $self->check_user($self->{backend2_store}, $expected_move);
+    $self->check_user($self->{backend2},
+                      $self->{backend2_store},
+                      $expected_move);
 
     # frontend should now say the new mailbox locations
     # XXX is there a better way to discover this?
@@ -1077,6 +1087,7 @@ sub test_xfer_no_user_intermediates
 
     # set up some data for cassandane on backend1
     my $expected = $self->populate_user(
+        $self->{instance},
         $self->{backend1_store},
         [qw(INBOX Big Big/Red Big/Red/Dog)]
     );
@@ -1103,7 +1114,7 @@ sub test_xfer_no_user_intermediates
     }
 
     # everything should still be on the original backend
-    $self->check_user($self->{backend1_store}, $expected);
+    $self->check_user($self->{instance}, $self->{backend1_store}, $expected);
 }
 
 # XXX test_xfer_partition

--- a/Cassandane/Cyrus/Replication.pm
+++ b/Cassandane/Cyrus/Replication.pm
@@ -42,8 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 use DateTime;
-use Digest::file qw(digest_file_hex);
-use File::Temp qw/tempfile/;
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
@@ -659,82 +657,6 @@ sub test_alternate_globalannots
     xlog $self, "initial replication was successful";
 
     $self->assert(1);
-}
-
-sub assert_sieve_exists
-{
-    my ($self, $instance, $user, $scriptname, $bc_only) = @_;
-
-    my $sieve_dir = $instance->get_sieve_script_dir($user);
-
-    $self->assert(( -f "$sieve_dir/$scriptname.bc" ));
-
-    if ($bc_only == 0) {
-        $self->assert(( -f "$sieve_dir/$scriptname.script" ));
-    }
-}
-
-sub assert_sieve_not_exists
-{
-    my ($self, $instance, $user, $scriptname, $bc_only) = @_;
-
-    my $sieve_dir = $instance->get_sieve_script_dir($user);
-
-    $self->assert(( ! -f "$sieve_dir/$scriptname.bc" ));
-
-    if ($bc_only == 0) {
-        $self->assert(( ! -f "$sieve_dir/$scriptname.script" ));
-    }
-}
-
-sub assert_sieve_active
-{
-    my ($self, $instance, $user, $scriptname) = @_;
-
-    my $sieve_dir = $instance->get_sieve_script_dir($user);
-
-    $self->assert(( -l "$sieve_dir/defaultbc" ));
-    $self->assert_str_equals("$scriptname.bc", readlink "$sieve_dir/defaultbc");
-}
-
-sub assert_sieve_noactive
-{
-    my ($self, $instance, $user) = @_;
-
-    my $sieve_dir = $instance->get_sieve_script_dir($user);
-
-    $self->assert(( ! -e "$sieve_dir/defaultbc" ),
-                  "$sieve_dir/defaultbc exists");
-    $self->assert(( ! -l "$sieve_dir/defaultbc" ),
-                  "dangling $sieve_dir/defaultbc symlink exists");
-}
-
-sub assert_sieve_matches
-{
-    my ($self, $instance, $user, $scriptname, $scriptcontent) = @_;
-
-    my $sieve_dir = $instance->get_sieve_script_dir($user);
-
-    my $bcname = "$sieve_dir/$scriptname.bc";
-
-    $self->assert(( -f $bcname ));
-
-    # compile $scriptcontent and compare digests of bytecode
-    my (undef, $tmp) = tempfile('scriptXXXXX', OPEN => 0,
-                                DIR => $instance->{basedir} . "/tmp");
-    open my $f, '>', $tmp or die "open: $!";
-    print $f $scriptcontent;
-    close $f;
-
-    my (undef, $filename) = tempfile('tmpXXXXXX', OPEN => 0,
-        DIR => $instance->{basedir} . "/tmp");
-
-    $instance->run_command({ redirects => {stdin => \$scriptcontent},
-                             cyrus => 1,
-                           },
-                           'sievec', $tmp, "$filename");
-    $self->assert_str_equals(digest_file_hex($bcname, "MD5"),
-                             digest_file_hex($filename, "MD5"));
 }
 
 sub test_sieve_replication

--- a/Cassandane/Cyrus/Replication.pm
+++ b/Cassandane/Cyrus/Replication.pm
@@ -720,11 +720,19 @@ sub assert_sieve_matches
     $self->assert(( -f $bcname ));
 
     # compile $scriptcontent and compare digests of bytecode
+    my (undef, $tmp) = tempfile('scriptXXXXX', OPEN => 0,
+                                DIR => $instance->{basedir} . "/tmp");
+    open my $f, '>', $tmp or die "open: $!";
+    print $f $scriptcontent;
+    close $f;
+
     my (undef, $filename) = tempfile('tmpXXXXXX', OPEN => 0,
         DIR => $instance->{basedir} . "/tmp");
 
-    $self->{instance}->run_command({redirects => {stdin => \$scriptcontent}},
-                                   'sievec', '-', "$filename");
+    $instance->run_command({ redirects => {stdin => \$scriptcontent},
+                             cyrus => 1,
+                           },
+                           'sievec', $tmp, "$filename");
     $self->assert_str_equals(digest_file_hex($bcname, "MD5"),
                              digest_file_hex($filename, "MD5"));
 }

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -1381,10 +1381,12 @@ sub assert_sieve_exists
 
     my $sieve_dir = $instance->get_sieve_script_dir($user);
 
-    $self->assert(( -f "$sieve_dir/$scriptname.bc" ));
+    $self->assert(( -f "$sieve_dir/$scriptname.bc" ),
+                  "$sieve_dir/$scriptname.bc: file not found");
 
     if ($bc_only == 0) {
-        $self->assert(( -f "$sieve_dir/$scriptname.script" ));
+        $self->assert(( -f "$sieve_dir/$scriptname.script" ),
+                      "$sieve_dir/$scriptname.script: file not found");
     }
 }
 
@@ -1394,10 +1396,12 @@ sub assert_sieve_not_exists
 
     my $sieve_dir = $instance->get_sieve_script_dir($user);
 
-    $self->assert(( ! -f "$sieve_dir/$scriptname.bc" ));
+    $self->assert(( ! -f "$sieve_dir/$scriptname.bc" ),
+                  "$sieve_dir/$scriptname.bc: file exists");
 
     if ($bc_only == 0) {
-        $self->assert(( ! -f "$sieve_dir/$scriptname.script" ));
+        $self->assert(( ! -f "$sieve_dir/$scriptname.script" ),
+                      "$sieve_dir/$scriptname.script: file exists");
     }
 }
 
@@ -1407,7 +1411,8 @@ sub assert_sieve_active
 
     my $sieve_dir = $instance->get_sieve_script_dir($user);
 
-    $self->assert(( -l "$sieve_dir/defaultbc" ));
+    $self->assert(( -l "$sieve_dir/defaultbc" ),
+                  "$sieve_dir/defaultbc: missing or not a symlink");
     $self->assert_str_equals("$scriptname.bc", readlink "$sieve_dir/defaultbc");
 }
 
@@ -1431,7 +1436,8 @@ sub assert_sieve_matches
 
     my $bcname = "$sieve_dir/$scriptname.bc";
 
-    $self->assert(( -f $bcname ));
+    $self->assert(( -f $bcname ),
+                  "$sieve_dir/$scriptname.bc: file not found");
 
     # compile $scriptcontent and compare digests of bytecode
     my (undef, $tmp) = tempfile('scriptXXXXX', OPEN => 0,

--- a/Cassandane/Cyrus/TestCase.pm
+++ b/Cassandane/Cyrus/TestCase.pm
@@ -44,6 +44,8 @@ use attributes;
 use Data::Dumper;
 use Scalar::Util qw(refaddr);
 use List::Util qw(uniq);
+use Digest::file qw(digest_file_hex);
+use File::Temp qw(tempfile);
 
 use lib '.';
 use base qw(Cassandane::Unit::TestCase);
@@ -1371,6 +1373,82 @@ sub assert_mailbox_structure
             "'$mailbox': found unexpected extra mailbox"
         );
     }
+}
+
+sub assert_sieve_exists
+{
+    my ($self, $instance, $user, $scriptname, $bc_only) = @_;
+
+    my $sieve_dir = $instance->get_sieve_script_dir($user);
+
+    $self->assert(( -f "$sieve_dir/$scriptname.bc" ));
+
+    if ($bc_only == 0) {
+        $self->assert(( -f "$sieve_dir/$scriptname.script" ));
+    }
+}
+
+sub assert_sieve_not_exists
+{
+    my ($self, $instance, $user, $scriptname, $bc_only) = @_;
+
+    my $sieve_dir = $instance->get_sieve_script_dir($user);
+
+    $self->assert(( ! -f "$sieve_dir/$scriptname.bc" ));
+
+    if ($bc_only == 0) {
+        $self->assert(( ! -f "$sieve_dir/$scriptname.script" ));
+    }
+}
+
+sub assert_sieve_active
+{
+    my ($self, $instance, $user, $scriptname) = @_;
+
+    my $sieve_dir = $instance->get_sieve_script_dir($user);
+
+    $self->assert(( -l "$sieve_dir/defaultbc" ));
+    $self->assert_str_equals("$scriptname.bc", readlink "$sieve_dir/defaultbc");
+}
+
+sub assert_sieve_noactive
+{
+    my ($self, $instance, $user) = @_;
+
+    my $sieve_dir = $instance->get_sieve_script_dir($user);
+
+    $self->assert(( ! -e "$sieve_dir/defaultbc" ),
+                  "$sieve_dir/defaultbc exists");
+    $self->assert(( ! -l "$sieve_dir/defaultbc" ),
+                  "dangling $sieve_dir/defaultbc symlink exists");
+}
+
+sub assert_sieve_matches
+{
+    my ($self, $instance, $user, $scriptname, $scriptcontent) = @_;
+
+    my $sieve_dir = $instance->get_sieve_script_dir($user);
+
+    my $bcname = "$sieve_dir/$scriptname.bc";
+
+    $self->assert(( -f $bcname ));
+
+    # compile $scriptcontent and compare digests of bytecode
+    my (undef, $tmp) = tempfile('scriptXXXXX', OPEN => 0,
+                                DIR => $instance->{basedir} . "/tmp");
+    open my $f, '>', $tmp or die "open: $!";
+    print $f $scriptcontent;
+    close $f;
+
+    my (undef, $filename) = tempfile('tmpXXXXXX', OPEN => 0,
+        DIR => $instance->{basedir} . "/tmp");
+
+    $instance->run_command({ redirects => {stdin => \$scriptcontent},
+                             cyrus => 1,
+                           },
+                           'sievec', $tmp, "$filename");
+    $self->assert_str_equals(digest_file_hex($bcname, "MD5"),
+                             digest_file_hex($filename, "MD5"));
 }
 
 1;

--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -612,6 +612,7 @@ sub _build_skeleton
         'conf/log/cassandane',
         'conf/log/user2',
         'conf/log/foo',
+        'conf/log/mailproxy',
         'conf/log/mupduser',
         'conf/log/postman',
         'conf/log/repluser',


### PR DESCRIPTION
Adds a sieve script to `populate_user()` and `check_user()` methods, so that any tests that use these functions will end up verifying sieve data too.

For now, this has #178's changes embedded in it so I can test a sieve-in-uuid-mailbox Cyrus.  I'll need to clean it up later, or maybe just add my changes into that branch instead.